### PR TITLE
Align web app with relationship backend contracts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,207 +1,1542 @@
-import { useEffect, useState, type FormEvent, type ReactNode } from 'react';
-import { Navigate, Route, Routes, Link, useLocation, useNavigate, useParams } from 'react-router-dom';
-import { ArrowRight, Bookmark, ChevronRight, Circle, Download, Heart, LockKeyhole, MessageCircle, Plus, Send, ShieldCheck, Sparkles, Trash2 } from 'lucide-react';
-import { AppShell, Brand, ButtonLink, Disclaimer, Page, PageTracker, PublicHeader } from './components';
-import { peopleStore, type Person } from './lib/storage'; import { auth } from './lib/firebase'; import { firebaseReady } from './lib/env'; import { track, setAnalyticsConsent } from './lib/analytics';
-import { accountApi, normalizeTimezone, routeForAccount, type AccountState, type ProfileInput } from './lib/account';
-import { BirthProfileForm } from './BirthProfileForm';
-import { ChartPage } from './ChartPage';
-import { birthProfilesApi, type BirthProfileInput } from './lib/birthProfiles';
-import { ApiError } from './lib/api';
-import { DatingProfilePage } from './DatingProfilePage';
-import { ProfileTabs } from './ProfileTabs';
-import { BlueprintPage, NewRelationshipPage, PeoplePage, PersonPage, RelationshipPage, RelationshipReportPage, RelationshipsPage } from './RelationshipPages';
-import { wakeBackend } from './lib/backendWake';
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
+import {
+  Navigate,
+  Route,
+  Routes,
+  Link,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
+import {
+  ArrowRight,
+  Bookmark,
+  ChevronRight,
+  Circle,
+  Download,
+  Heart,
+  LockKeyhole,
+  MessageCircle,
+  Plus,
+  Send,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+import {
+  AppShell,
+  Brand,
+  ButtonLink,
+  Disclaimer,
+  Page,
+  PageTracker,
+  PublicHeader,
+} from "./components";
+import { peopleStore, type Person } from "./lib/storage";
+import { auth } from "./lib/firebase";
+import { firebaseReady } from "./lib/env";
+import { track, setAnalyticsConsent } from "./lib/analytics";
+import {
+  accountApi,
+  normalizeTimezone,
+  routeForAccount,
+  type AccountState,
+  type ProfileInput,
+} from "./lib/account";
+import { BirthProfileForm } from "./BirthProfileForm";
+import { ChartPage } from "./ChartPage";
+import { birthProfilesApi, type BirthProfileInput } from "./lib/birthProfiles";
+import { ApiError } from "./lib/api";
+import { DatingProfilePage } from "./DatingProfilePage";
+import { ProfileTabs } from "./ProfileTabs";
+import {
+  BlueprintPage,
+  NewRelationshipPage,
+  PeoplePage,
+  PersonPage,
+  RelationshipPage,
+  RelationshipReportPage,
+  RelationshipsPage,
+} from "./RelationshipPages";
+import { wakeBackend } from "./lib/backendWake";
+import { AskPage, SavedPage, SettingsPage } from "./ConnectedPages";
+import { relationshipsApi, type Relationship } from "./lib/relationships";
 
-const benefits=[['Private by design','Create personal profiles for the people in your life. Nothing becomes public.'],['More than a score','Explore attraction, communication, conflict and emotional rhythm in context.'],['Questions that go deeper','Ask about a connection or your own patterns—and get grounded reflections.']];
-function apiFormMessage(error:unknown,fallback:string){
-  if(error instanceof ApiError&&error.fields){
-    const details=Object.entries(error.fields).map(([field,message])=>`${field.replaceAll('_',' ')}: ${message}`).join(' · ');
-    if(details)return details;
+const benefits = [
+  [
+    "Private by design",
+    "Create personal profiles for the people in your life. Nothing becomes public.",
+  ],
+  [
+    "More than a score",
+    "Explore attraction, communication, conflict and emotional rhythm in context.",
+  ],
+  [
+    "Questions that go deeper",
+    "Ask about a connection or your own patterns—and get grounded reflections.",
+  ],
+];
+function apiFormMessage(error: unknown, fallback: string) {
+  if (error instanceof ApiError && error.fields) {
+    const details = Object.entries(error.fields)
+      .map(([field, message]) => `${field.replaceAll("_", " ")}: ${message}`)
+      .join(" · ");
+    if (details) return details;
   }
-  return error instanceof ApiError?error.message:fallback;
+  return error instanceof ApiError ? error.message : fallback;
 }
-function Landing(){useEffect(()=>wakeBackend(),[]);return <div className="public-page"><PublicHeader/><main><section className="hero"><div className="hero-copy"><p className="eyebrow">ASTROLOGY FOR REAL RELATIONSHIPS</p><h1>Understand the patterns <em>between you.</em></h1><p className="lead">Create private birth profiles, explore compatibility and ask personal questions about love, dating and connection.</p><div className="actions"><ButtonLink to="/signup">Create my profile <ArrowRight size={18}/></ButtonLink><a href="#how" className="quiet-link">See how it works</a></div><p className="micro"><LockKeyhole size={14}/> Your profiles are private and never discoverable.</p></div><CompatibilityPreview/></section><section className="manifesto"><p>Love is complicated.</p><h2>Your patterns don’t have to be.</h2></section><section className="benefit-grid">{benefits.map(([title,text],i)=><article key={title}><span>0{i+1}</span><h3>{title}</h3><p>{text}</p></article>)}</section><section id="how" className="how"><p className="eyebrow">HOW IT WORKS</p><h2>Two charts. One thoughtful conversation.</h2><div className="steps"><div><b>01</b><h3>Create your birth profile</h3><p>Tell us what you know. An unknown birth time is okay—we’ll explain what changes.</p></div><div><b>02</b><h3>Add someone privately</h3><p>A partner, crush, ex or friend. They are never notified or listed publicly.</p></div><div><b>03</b><h3>Explore the connection</h3><p>Read a nuanced report, then ask the questions that are actually on your mind.</p></div></div></section><section className="questions"><p className="eyebrow">QUESTIONS WORTH ASKING</p>{['What creates the strongest attraction between us?','Where might our communication break down?','What should I understand before committing?'].map(q=><p key={q}>{q}<ArrowRight/></p>)}</section><section className="privacy-callout"><ShieldCheck/><div><p className="eyebrow">PRIVATE MEANS PRIVATE</p><h2>Your love life isn’t content.</h2><p>Profiles you create are visible only to you. Share cards hide birth details and use aliases by default.</p></div></section><section className="final-cta"><p className="eyebrow">A DIFFERENT WAY TO REFLECT</p><h2>Start with what’s written in the sky. Keep the choice in your hands.</h2><ButtonLink to="/signup">Create my profile <ArrowRight size={18}/></ButtonLink></section></main><Footer/></div>}
-function CompatibilityPreview(){return <div className="preview"><div className="orbit"><span className="node one">A</span><span className="node two">M</span><div className="score"><small>COMPATIBILITY</small><strong>82</strong><span>/ 100</span></div></div><div className="preview-foot"><span><i/> Magnetic honesty</span><span><i/> Different rhythms</span></div></div>}
-function Footer(){return <footer><Brand/><p>Private, personalized astrology for your love life.</p><nav><Link to="/about">About</Link><Link to="/privacy">Privacy</Link><Link to="/terms">Terms</Link></nav><small>© 2026 AstroMatch</small></footer>}
-function Legal({kind}:{kind:'about'|'privacy'|'terms'}){const copy={about:['Astrology for the space between people.','AstroMatch is a private reflection tool for understanding attraction, communication and emotional patterns—without turning people into profiles for public consumption.'],privacy:['Privacy, in plain language.','Your birth profiles and conversations are private account data. We do not sell personal information or use birth details, names, locations, emails or question text for analytics.'],terms:['A thoughtful tool, not a certainty machine.','Use AstroMatch for personal reflection and entertainment. Interpretations are tendencies, not guarantees, and should never replace your judgment or professional advice.']}[kind];return <div className="public-page"><PublicHeader/><main className="prose"><p className="eyebrow">{kind.toUpperCase()}</p><h1>{copy[0]}</h1><p className="lead">{copy[1]}</p><Disclaimer/></main><Footer/></div>}
-function AuthPage({signup=false}:{signup?:boolean}){
-  const nav=useNavigate();
-  const [loading,setLoading]=useState(false);
-  const [message,setMessage]=useState('');
+function Landing() {
+  useEffect(() => wakeBackend(), []);
+  return (
+    <div className="public-page">
+      <PublicHeader />
+      <main>
+        <section className="hero">
+          <div className="hero-copy">
+            <p className="eyebrow">ASTROLOGY FOR REAL RELATIONSHIPS</p>
+            <h1>
+              Understand the patterns <em>between you.</em>
+            </h1>
+            <p className="lead">
+              Create private birth profiles, explore compatibility and ask
+              personal questions about love, dating and connection.
+            </p>
+            <div className="actions">
+              <ButtonLink to="/signup">
+                Create my profile <ArrowRight size={18} />
+              </ButtonLink>
+              <a href="#how" className="quiet-link">
+                See how it works
+              </a>
+            </div>
+            <p className="micro">
+              <LockKeyhole size={14} /> Your profiles are private and never
+              discoverable.
+            </p>
+          </div>
+          <CompatibilityPreview />
+        </section>
+        <section className="manifesto">
+          <p>Love is complicated.</p>
+          <h2>Your patterns don’t have to be.</h2>
+        </section>
+        <section className="benefit-grid">
+          {benefits.map(([title, text], i) => (
+            <article key={title}>
+              <span>0{i + 1}</span>
+              <h3>{title}</h3>
+              <p>{text}</p>
+            </article>
+          ))}
+        </section>
+        <section id="how" className="how">
+          <p className="eyebrow">HOW IT WORKS</p>
+          <h2>Two charts. One thoughtful conversation.</h2>
+          <div className="steps">
+            <div>
+              <b>01</b>
+              <h3>Create your birth profile</h3>
+              <p>
+                Tell us what you know. An unknown birth time is okay—we’ll
+                explain what changes.
+              </p>
+            </div>
+            <div>
+              <b>02</b>
+              <h3>Add someone privately</h3>
+              <p>
+                A partner, crush, ex or friend. They are never notified or
+                listed publicly.
+              </p>
+            </div>
+            <div>
+              <b>03</b>
+              <h3>Explore the connection</h3>
+              <p>
+                Read a nuanced report, then ask the questions that are actually
+                on your mind.
+              </p>
+            </div>
+          </div>
+        </section>
+        <section className="questions">
+          <p className="eyebrow">QUESTIONS WORTH ASKING</p>
+          {[
+            "What creates the strongest attraction between us?",
+            "Where might our communication break down?",
+            "What should I understand before committing?",
+          ].map((q) => (
+            <p key={q}>
+              {q}
+              <ArrowRight />
+            </p>
+          ))}
+        </section>
+        <section className="privacy-callout">
+          <ShieldCheck />
+          <div>
+            <p className="eyebrow">PRIVATE MEANS PRIVATE</p>
+            <h2>Your love life isn’t content.</h2>
+            <p>
+              Profiles you create are visible only to you. Share cards hide
+              birth details and use aliases by default.
+            </p>
+          </div>
+        </section>
+        <section className="final-cta">
+          <p className="eyebrow">A DIFFERENT WAY TO REFLECT</p>
+          <h2>
+            Start with what’s written in the sky. Keep the choice in your hands.
+          </h2>
+          <ButtonLink to="/signup">
+            Create my profile <ArrowRight size={18} />
+          </ButtonLink>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+function CompatibilityPreview() {
+  return (
+    <div className="preview">
+      <div className="orbit">
+        <span className="node one">A</span>
+        <span className="node two">M</span>
+        <div className="score">
+          <small>COMPATIBILITY</small>
+          <strong>82</strong>
+          <span>/ 100</span>
+        </div>
+      </div>
+      <div className="preview-foot">
+        <span>
+          <i /> Magnetic honesty
+        </span>
+        <span>
+          <i /> Different rhythms
+        </span>
+      </div>
+    </div>
+  );
+}
+function Footer() {
+  return (
+    <footer>
+      <Brand />
+      <p>Private, personalized astrology for your love life.</p>
+      <nav>
+        <Link to="/about">About</Link>
+        <Link to="/privacy">Privacy</Link>
+        <Link to="/terms">Terms</Link>
+      </nav>
+      <small>© 2026 AstroMatch</small>
+    </footer>
+  );
+}
+function Legal({ kind }: { kind: "about" | "privacy" | "terms" }) {
+  const copy = {
+    about: [
+      "Astrology for the space between people.",
+      "AstroMatch is a private reflection tool for understanding attraction, communication and emotional patterns—without turning people into profiles for public consumption.",
+    ],
+    privacy: [
+      "Privacy, in plain language.",
+      "Your birth profiles and conversations are private account data. We do not sell personal information or use birth details, names, locations, emails or question text for analytics.",
+    ],
+    terms: [
+      "A thoughtful tool, not a certainty machine.",
+      "Use AstroMatch for personal reflection and entertainment. Interpretations are tendencies, not guarantees, and should never replace your judgment or professional advice.",
+    ],
+  }[kind];
+  return (
+    <div className="public-page">
+      <PublicHeader />
+      <main className="prose">
+        <p className="eyebrow">{kind.toUpperCase()}</p>
+        <h1>{copy[0]}</h1>
+        <p className="lead">{copy[1]}</p>
+        <Disclaimer />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+function AuthPage({ signup = false }: { signup?: boolean }) {
+  const nav = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
 
-  function authErrorMessage(error:unknown){
-    const code=typeof error==='object'&&error!==null&&'code' in error?String(error.code):'';
-    if(code==='auth/popup-closed-by-user'||code==='auth/cancelled-popup-request')return '';
-    if(code==='auth/popup-blocked')return 'Your browser blocked the Google sign-in window. Allow pop-ups and try again.';
-    if(code==='auth/unauthorized-domain')return 'Google sign-in is not authorized for this website yet.';
-    if(code==='auth/operation-not-allowed')return 'Google sign-in is not enabled for this Firebase project yet.';
-    return 'We couldn’t complete that request. Check your details or try again shortly.';
+  function authErrorMessage(error: unknown) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error
+        ? String(error.code)
+        : "";
+    if (
+      code === "auth/popup-closed-by-user" ||
+      code === "auth/cancelled-popup-request"
+    )
+      return "";
+    if (code === "auth/popup-blocked")
+      return "Your browser blocked the Google sign-in window. Allow pop-ups and try again.";
+    if (code === "auth/unauthorized-domain")
+      return "Google sign-in is not authorized for this website yet.";
+    if (code === "auth/operation-not-allowed")
+      return "Google sign-in is not enabled for this Firebase project yet.";
+    return "We couldn’t complete that request. Check your details or try again shortly.";
   }
 
-  async function submit(e:FormEvent<HTMLFormElement>){
+  async function submit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if(!auth){setMessage('Firebase sign-in is not configured yet.');return}
+    if (!auth) {
+      setMessage("Firebase sign-in is not configured yet.");
+      return;
+    }
     setLoading(true);
-    setMessage('');
-    const form=new FormData(e.currentTarget);
-    try{
-      const {createUserWithEmailAndPassword,signInWithEmailAndPassword,sendEmailVerification}=await import('firebase/auth');
-      const credential=signup
-        ?await createUserWithEmailAndPassword(auth,String(form.get('email')),String(form.get('password')))
-        :await signInWithEmailAndPassword(auth,String(form.get('email')),String(form.get('password')));
-      if(signup)await sendEmailVerification(credential.user);
-      track(signup?'sign_up_completed':'login_completed',{method:'email'});
-      const account=await accountApi.get();
+    setMessage("");
+    const form = new FormData(e.currentTarget);
+    try {
+      const {
+        createUserWithEmailAndPassword,
+        signInWithEmailAndPassword,
+        sendEmailVerification,
+      } = await import("firebase/auth");
+      const credential = signup
+        ? await createUserWithEmailAndPassword(
+            auth,
+            String(form.get("email")),
+            String(form.get("password")),
+          )
+        : await signInWithEmailAndPassword(
+            auth,
+            String(form.get("email")),
+            String(form.get("password")),
+          );
+      if (signup) await sendEmailVerification(credential.user);
+      track(signup ? "sign_up_completed" : "login_completed", {
+        method: "email",
+      });
+      const account = await accountApi.get();
       nav(routeForAccount(account));
-    }catch(error){
+    } catch (error) {
       setMessage(authErrorMessage(error));
-    }finally{
+    } finally {
       setLoading(false);
     }
   }
 
-  async function continueWithGoogle(){
-    if(!auth){setMessage('Firebase sign-in is not configured yet.');return}
+  async function continueWithGoogle() {
+    if (!auth) {
+      setMessage("Firebase sign-in is not configured yet.");
+      return;
+    }
     setLoading(true);
-    setMessage('');
-    try{
-      const {GoogleAuthProvider,getAdditionalUserInfo,signInWithPopup}=await import('firebase/auth');
-      const provider=new GoogleAuthProvider();
-      provider.setCustomParameters({prompt:'select_account'});
-      const credential=await signInWithPopup(auth,provider);
-      const isNewUser=getAdditionalUserInfo(credential)?.isNewUser??false;
-      track(isNewUser?'sign_up_completed':'login_completed',{method:'google'});
-      const account=await accountApi.get();
+    setMessage("");
+    try {
+      const { GoogleAuthProvider, getAdditionalUserInfo, signInWithPopup } =
+        await import("firebase/auth");
+      const provider = new GoogleAuthProvider();
+      provider.setCustomParameters({ prompt: "select_account" });
+      const credential = await signInWithPopup(auth, provider);
+      const isNewUser = getAdditionalUserInfo(credential)?.isNewUser ?? false;
+      track(isNewUser ? "sign_up_completed" : "login_completed", {
+        method: "google",
+      });
+      const account = await accountApi.get();
       nav(routeForAccount(account));
-    }catch(error){
+    } catch (error) {
       setMessage(authErrorMessage(error));
-    }finally{
+    } finally {
       setLoading(false);
     }
   }
 
-  return <div className="auth-page"><header><Brand/><Link to={signup?'/login':'/signup'}>{signup?'Sign in':'Create account'}</Link></header><main><p className="eyebrow">{signup?'BEGIN YOUR PROFILE':'WELCOME BACK'}</p><h1>{signup?'A little about you, then the stars.':'Return to your private space.'}</h1><button type="button" className="google" onClick={continueWithGoogle} disabled={!firebaseReady||loading}>{loading?'One moment…':'Continue with Google'}</button><div className="auth-divider"><span>or continue with email</span></div><form onSubmit={submit}><label>Email<input name="email" type="email" autoComplete="email" required/></label><label>Password<input name="password" type="password" minLength={8} autoComplete={signup?'new-password':'current-password'} required/><small>Use at least 8 characters.</small></label>{message&&<p role="alert" className="form-message">{message}</p>}<button className="button" disabled={loading}>{loading?'One moment…':signup?'Create account':'Sign in'} <ArrowRight size={18}/></button></form><p className="micro">By continuing, you agree to our <Link to="/terms">Terms</Link> and acknowledge our <Link to="/privacy">Privacy Policy</Link>.</p></main></div>
+  return (
+    <div className="auth-page">
+      <header>
+        <Brand />
+        <Link to={signup ? "/login" : "/signup"}>
+          {signup ? "Sign in" : "Create account"}
+        </Link>
+      </header>
+      <main>
+        <p className="eyebrow">
+          {signup ? "BEGIN YOUR PROFILE" : "WELCOME BACK"}
+        </p>
+        <h1>
+          {signup
+            ? "A little about you, then the stars."
+            : "Return to your private space."}
+        </h1>
+        <button
+          type="button"
+          className="google"
+          onClick={continueWithGoogle}
+          disabled={!firebaseReady || loading}
+        >
+          {loading ? "One moment…" : "Continue with Google"}
+        </button>
+        <div className="auth-divider">
+          <span>or continue with email</span>
+        </div>
+        <form onSubmit={submit}>
+          <label>
+            Email
+            <input name="email" type="email" autoComplete="email" required />
+          </label>
+          <label>
+            Password
+            <input
+              name="password"
+              type="password"
+              minLength={8}
+              autoComplete={signup ? "new-password" : "current-password"}
+              required
+            />
+            <small>Use at least 8 characters.</small>
+          </label>
+          {message && (
+            <p role="alert" className="form-message">
+              {message}
+            </p>
+          )}
+          <button className="button" disabled={loading}>
+            {loading ? "One moment…" : signup ? "Create account" : "Sign in"}{" "}
+            <ArrowRight size={18} />
+          </button>
+        </form>
+        <p className="micro">
+          By continuing, you agree to our <Link to="/terms">Terms</Link> and
+          acknowledge our <Link to="/privacy">Privacy Policy</Link>.
+        </p>
+      </main>
+    </div>
+  );
 }
-function Dashboard(){return <AppShell><Page eyebrow="THURSDAY · JULY 23" title="Good evening, Deepak."/><section className="daily"><span className="eyebrow">YOUR RELATIONSHIP WEATHER</span><h2>Say the true thing gently.</h2><p>Connection grows when honesty arrives without a demand for an immediate answer. Leave a little room around what you mean.</p><div className="tags"><span>Venus · expression</span><span>Moon · sensitivity</span></div></section><div className="dash-grid"><Link className="action-card" to="/ask"><MessageCircle/><div><span>ASK ASTROMATCH</span><h3>What’s on your mind?</h3></div><ChevronRight/></Link><Link className="action-card" to="/matches/new"><Heart/><div><span>NEW CONNECTION</span><h3>Explore a match</h3></div><ChevronRight/></Link></div><section className="section"><div className="section-head"><p className="eyebrow">LATEST MATCH</p><Link to="/matches">View all</Link></div><Link to="/matches/demo/report" className="match-card"><div><span>A</span><span>M</span></div><section><small>YOU + MAYA</small><h3>A bond built on candor</h3><p>Strong emotional recognition · Different pacing</p></section><strong>82</strong></Link></section><p className="fixture-note">Preview content is illustrative until your API is connected.</p></AppShell>}
-export function People(){const [people,setPeople]=useState<Person[]>(peopleStore.list());function remove(id:string){if(confirm('Delete this private profile?')){peopleStore.remove(id);setPeople(peopleStore.list());track('person_deleted')}}return <AppShell><Page eyebrow="PRIVATE PROFILES" title="People" action={<Link className="icon-button" to="/people/new" aria-label="Add a person"><Plus/></Link>}/><p className="page-intro">The people you add are never notified and never appear publicly.</p>{people.length?<div className="list">{people.map(p=><article className="list-row" key={p.id}><Link to={`/people/${p.id}`}><span className="avatar">{p.name[0]}</span><div><h3>{p.name}</h3><p>{p.relationship} · {p.birthplace}</p></div></Link><button onClick={()=>remove(p.id)} aria-label={`Delete ${p.name}`}><Trash2/></button></article>)}</div>:<Empty icon={<Heart/>} title="No one here yet" text="Add someone privately when there’s a connection you want to understand." action="Add a person" to="/people/new"/>}</AppShell>}
-export function PersonForm(){const {personId}=useParams();const existing=peopleStore.list().find(p=>p.id===personId);const nav=useNavigate();function submit(e:FormEvent<HTMLFormElement>){e.preventDefault();const f=new FormData(e.currentTarget);peopleStore.save({id:existing?.id??crypto.randomUUID(),name:String(f.get('name')),relationship:String(f.get('relationship')),birthDate:String(f.get('birthDate')),birthTimeStatus:String(f.get('birthTimeStatus')) as Person['birthTimeStatus'],birthplace:String(f.get('birthplace')),notes:String(f.get('notes'))});track(existing?'person_updated':'person_created',{relationship_type:String(f.get('relationship')),birth_time_quality:String(f.get('birthTimeStatus'))});nav('/people')}return <AppShell><Page eyebrow={existing?'EDIT PROFILE':'ADD SOMEONE'} title={existing?existing.name:'Who are we looking at?'}/><form className="stack-form" onSubmit={submit}><label>Private name or alias<input name="name" defaultValue={existing?.name} required/></label><label>Relationship<select name="relationship" defaultValue={existing?.relationship}><option>Partner</option><option>Crush</option><option>Ex</option><option>Friend</option><option>Custom</option></select></label><label>Date of birth<input name="birthDate" type="date" defaultValue={existing?.birthDate} required/></label><fieldset><legend>Birth time</legend><div className="choice-row">{['exact','approximate','unknown'].map(x=><label key={x}><input type="radio" name="birthTimeStatus" value={x} defaultChecked={(existing?.birthTimeStatus??'unknown')===x}/>{x}</label>)}</div><small>Without an exact time, house and ascendant interpretations may be less precise.</small></fieldset><label>Birthplace<input name="birthplace" defaultValue={existing?.birthplace} placeholder="City, country" required/><small>Manual entry for now. Confirm the normalized place when lookup is connected.</small></label><label>Notes <span>optional</span><textarea name="notes" defaultValue={existing?.notes}/></label><div className="notice"><LockKeyhole/>This person is not notified. Avoid sensitive information without their permission.</div><button className="button">Save private profile</button></form></AppShell>}
-function Empty({icon,title,text,action,to}:{icon:ReactNode;title:string;text:string;action:string;to:string}){return <div className="empty">{icon}<h2>{title}</h2><p>{text}</p><ButtonLink to={to}>{action}</ButtonLink></div>}
-export function Matches(){return <AppShell><Page eyebrow="CONNECTIONS" title="Your matches" action={<Link className="icon-button" to="/matches/new"><Plus/></Link>}/><div className="list"><Link className="match-card" to="/matches/demo/report"><div><span>A</span><span>M</span></div><section><small>OVERALL COMPATIBILITY</small><h3>You + Maya</h3><p>Communication · Attraction · Emotional rhythm</p></section><strong>82</strong></Link></div><p className="fixture-note">Preview report · illustrative data</p></AppShell>}
-export function NewMatch(){const [phase,setPhase]=useState('');const nav=useNavigate();function generate(e:FormEvent){e.preventDefault();track('match_generation_requested');const phases=['Preparing both charts','Comparing placements','Finding major themes','Writing your report'];let i=0;setPhase(phases[0]);const timer=setInterval(()=>{i++;if(i===phases.length){clearInterval(timer);track('match_generation_completed',{focus:'overall',birth_data_quality:'mixed'});nav('/matches/demo/report')}else setPhase(phases[i])},650)}return <AppShell><Page eyebrow="NEW MATCH" title="Explore a connection"/><form className="stack-form" onSubmit={generate}><label>Your profile<select><option>Deepak · birth profile</option></select></label><label>The other person<select required><option value="">Choose a private profile</option>{peopleStore.list().map(p=><option key={p.id}>{p.name}</option>)}<option>Maya · preview</option></select></label><fieldset><legend>What do you want to understand?</legend><div className="radio-stack">{['Overall compatibility','Attraction','Emotional compatibility','Communication','Conflict patterns','Long-term potential'].map((x,i)=><label key={x}><input type="radio" name="focus" defaultChecked={!i}/><span>{x}</span><Circle/></label>)}</div></fieldset><div className="notice"><Sparkles/>One profile has an unknown birth time. We’ll avoid house-based certainty and label the report’s confidence.</div><button className="button">Generate report</button>{phase&&<div className="generation" role="status" aria-live="polite"><span/><p>{phase}</p></div>}</form></AppShell>}
-export function Report(){const sections=[['Strongest connection','You make it easier for each other to name what usually stays unspoken. Curiosity is a shared love language here.'],['Primary friction','One of you reaches for clarity while the other needs room. The pattern works best when space has a clear return point.'],['Attraction','Warmth and intrigue arrive together. Venus–Mars contact suggests a lively pull, while Mercury keeps attraction mentally engaged.'],['Emotional rhythm','There is genuine recognition, though your nervous systems may move at different speeds. Neither pace is the “right” one.'],['Communication','Direct questions help. Assumptions do not. A strong Mercury link supports repair when both people stay specific.'],['Conflict and repair','Pause before solving. Name the feeling, then the request. This connection benefits from structure after intensity.'],['Long-term tendencies','Shared growth is possible when independence is treated as part of intimacy—not evidence against it.']];return <AppShell><Page eyebrow="COMPATIBILITY REPORT" title="You + Maya"/><div className="report-score"><div><small>OVERALL</small><strong>82</strong><span>/100</span></div><section><span className="quality">MODERATE CONFIDENCE</span><h2>A bond built on candor</h2><p>Strong mutual recognition with different emotional pacing.</p></section></div><div className="score-strip">{[['Attraction',88],['Emotional',76],['Communication',84],['Long-term',78]].map(([x,n])=><div key={x}><span>{x}</span><b>{n}</b><i style={{width:`${n}%`}}/></div>)}</div><div className="report-body">{sections.map(([title,text],i)=><section key={title}><span>0{i+1}</span><div><h2>{title}</h2><p>{text}</p></div></section>)}<section><span>08</span><div><h2>Reflection prompts</h2><ul><li>What does reassurance look like to each of you?</li><li>How can you ask for space without creating ambiguity?</li><li>Which differences feel generative rather than threatening?</li></ul></div></section><section><span>09</span><div><h2>Astrological basis</h2><p>Venus trine Mars · Mercury sextile Mercury · Moon square Saturn. Birth-time uncertainty limits house and ascendant interpretation.</p></div></section></div><div className="report-actions"><ButtonLink to="/ask">Ask about this match</ButtonLink><button className="button secondary"><Bookmark/> Save</button><button className="button secondary"><Download/> Share card</button></div><Disclaimer/></AppShell>}
-function Ask(){const prompts=['Why do I lose interest once someone likes me?','What creates the strongest attraction between us?','Where might our communication break down?'];const [messages,setMessages]=useState<{role:'me'|'astro';text:string}[]>([]);const [text,setText]=useState('');const [waiting,setWaiting]=useState(false);useEffect(()=>track('ask_screen_viewed'),[]);function submit(e:FormEvent){e.preventDefault();if(!text.trim())return;const q=text;setMessages(m=>[...m,{role:'me',text:q}]);setText('');setWaiting(true);track('astrology_question_submitted',{context_type:'love_life'});setTimeout(()=>{setMessages(m=>[...m,{role:'astro',text:'Your chart suggests that attraction can feel safest while it remains open-ended. When interest becomes certain, closeness may bring old questions about autonomy to the surface. This is a pattern to notice—not a verdict. [Venus–Uranus; Moon–Saturn]'}]);setWaiting(false);track('astrology_answer_completed',{context_type:'love_life'})},900)}return <AppShell><div className="chat"><Page eyebrow="A PRIVATE CONVERSATION" title="Ask AstroMatch"/><div className="mode-row"><button className="active">My love life</button><button>This match</button><button>Communication</button></div><div className="messages" aria-live="polite">{!messages.length&&<div className="chat-intro"><Sparkles/><h2>What are you trying to understand?</h2><p>Ask about a pattern, a connection or the part you can’t quite name.</p><div>{prompts.map(p=><button key={p} onClick={()=>{setText(p);track('suggested_question_clicked',{category:'love_life'})}}>{p}<ArrowRight/></button>)}</div></div>}{messages.map((m,i)=><div key={i} className={`message ${m.role}`}>{m.role==='astro'&&<small>ASTROMATCH · INTERPRETATION</small>}<p>{m.text}</p>{m.role==='astro'&&<div className="feedback"><span>Was this helpful?</span><button>Yes</button><button>Not quite</button></div>}</div>)}{waiting&&<div className="thinking"><i/><i/><i/> Waking AstroMatch up…</div>}</div><form className="composer" onSubmit={submit}><textarea value={text} onChange={e=>setText(e.target.value)} rows={1} placeholder="Ask what’s on your mind…" aria-label="Your question"/><button disabled={!text.trim()||waiting} aria-label="Send"><Send/></button></form></div></AppShell>}
-function Saved(){return <AppShell><Page eyebrow="YOUR LIBRARY" title="Saved"/><div className="tabs"><button className="active">Reports</button><button>Conversations</button><button>Share cards</button></div><Empty icon={<Bookmark/>} title="Keep the useful parts close" text="Reports and conversations you save will live here." action="Explore a match" to="/matches"/></AppShell>}
-function Settings(){const [consent,setConsent]=useState(localStorage.getItem('am:analytics-consent')==='granted');return <AppShell><div className="settings-profile-shell"><Page eyebrow="YOUR ACCOUNT" title="Settings"/><ProfileTabs/><div className="settings-list"><section><h2>Privacy</h2><label className="toggle">Anonymous product analytics<input type="checkbox" checked={consent} onChange={e=>{setConsent(e.target.checked);setAnalyticsConsent(e.target.checked)}}/><i/></label><p>Never includes names, email, birth data, locations or question text.</p></section><section><h2>Dating profile</h2><button disabled>Photos <span>Backend support needed</span></button><button disabled>Prompts and answers <span>Backend support needed</span></button><button disabled>Discovery preferences <span>Backend support needed</span></button></section><section><h2>Account</h2><button>Export my data <span>Coming soon</span></button><button>Notifications <span>Coming soon</span></button><button onClick={async()=>{await auth?.signOut();track('logout_completed')}}>Log out</button><button className="danger">Delete account</button></section><section><h2>Legal</h2><Link to="/privacy">Privacy policy <ChevronRight/></Link><Link to="/terms">Terms of use <ChevronRight/></Link></section></div></div></AppShell>}
-function Onboarding(){
-  const nav=useNavigate();
-  const [account,setAccount]=useState<AccountState|null>(null);
-  const [loading,setLoading]=useState(true);
-  const [message,setMessage]=useState('');
+function Dashboard() {
+  const [relationships, setRelationships] = useState<Relationship[]>([]);
+  const [preferredName, setPreferredName] = useState("");
+  useEffect(() => {
+    void Promise.all([accountApi.get(), relationshipsApi.all()]).then(
+      ([account, items]) => {
+        setPreferredName(account.profile?.preferred_name ?? "");
+        setRelationships(items);
+      },
+    );
+  }, []);
+  const latest = relationships[0];
+  return (
+    <AppShell>
+      <Page
+        eyebrow={new Intl.DateTimeFormat(undefined, {
+          weekday: "long",
+          month: "long",
+          day: "numeric",
+        }).format(new Date())}
+        title={`Welcome${preferredName ? `, ${preferredName}` : ""}.`}
+      />
+      <section className="daily">
+        <span className="eyebrow">YOUR RELATIONSHIP WEATHER</span>
+        <h2>Say the true thing gently.</h2>
+        <p>
+          Connection grows when honesty arrives without a demand for an
+          immediate answer. Leave a little room around what you mean.
+        </p>
+        <div className="tags">
+          <span>Venus · expression</span>
+          <span>Moon · sensitivity</span>
+        </div>
+      </section>
+      <div className="dash-grid">
+        <Link className="action-card" to="/ask">
+          <MessageCircle />
+          <div>
+            <span>ASK ASTROMATCH</span>
+            <h3>What’s on your mind?</h3>
+          </div>
+          <ChevronRight />
+        </Link>
+        <Link className="action-card" to="/relationships/new">
+          <Heart />
+          <div>
+            <span>NEW CONNECTION</span>
+            <h3>Explore a relationship</h3>
+          </div>
+          <ChevronRight />
+        </Link>
+      </div>
+      <section className="section">
+        <div className="section-head">
+          <p className="eyebrow">LATEST RELATIONSHIP</p>
+          <Link to="/relationships">View all</Link>
+        </div>
+        {latest ? (
+          <Link to={`/relationships/${latest.id}`} className="match-card">
+            <div>
+              <span>A</span>
+              <span>{latest.person?.displayName.slice(0, 1) ?? "·"}</span>
+            </div>
+            <section>
+              <small>PRIVATE RELATIONSHIP</small>
+              <h3>
+                {latest.title ??
+                  latest.person?.displayName ??
+                  "Relationship analysis"}
+              </h3>
+              <p>
+                {latest.headline ??
+                  latest.qualitativeLabel ??
+                  latest.compatibilityStatus.replaceAll("_", " ")}
+              </p>
+            </section>
+            {typeof latest.score === "number" && (
+              <strong>{Math.round(latest.score)}</strong>
+            )}
+          </Link>
+        ) : (
+          <div className="empty">
+            <Heart />
+            <h2>Your relationship space is ready</h2>
+            <p>Add someone privately to begin a compatibility analysis.</p>
+            <ButtonLink to="/relationships/new">Start an analysis</ButtonLink>
+          </div>
+        )}
+      </section>
+    </AppShell>
+  );
+}
+export function People() {
+  const [people, setPeople] = useState<Person[]>(peopleStore.list());
+  function remove(id: string) {
+    if (confirm("Delete this private profile?")) {
+      peopleStore.remove(id);
+      setPeople(peopleStore.list());
+      track("person_deleted");
+    }
+  }
+  return (
+    <AppShell>
+      <Page
+        eyebrow="PRIVATE PROFILES"
+        title="People"
+        action={
+          <Link
+            className="icon-button"
+            to="/people/new"
+            aria-label="Add a person"
+          >
+            <Plus />
+          </Link>
+        }
+      />
+      <p className="page-intro">
+        The people you add are never notified and never appear publicly.
+      </p>
+      {people.length ? (
+        <div className="list">
+          {people.map((p) => (
+            <article className="list-row" key={p.id}>
+              <Link to={`/people/${p.id}`}>
+                <span className="avatar">{p.name[0]}</span>
+                <div>
+                  <h3>{p.name}</h3>
+                  <p>
+                    {p.relationship} · {p.birthplace}
+                  </p>
+                </div>
+              </Link>
+              <button
+                onClick={() => remove(p.id)}
+                aria-label={`Delete ${p.name}`}
+              >
+                <Trash2 />
+              </button>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <Empty
+          icon={<Heart />}
+          title="No one here yet"
+          text="Add someone privately when there’s a connection you want to understand."
+          action="Add a person"
+          to="/people/new"
+        />
+      )}
+    </AppShell>
+  );
+}
+export function PersonForm() {
+  const { personId } = useParams();
+  const existing = peopleStore.list().find((p) => p.id === personId);
+  const nav = useNavigate();
+  function submit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const f = new FormData(e.currentTarget);
+    peopleStore.save({
+      id: existing?.id ?? crypto.randomUUID(),
+      name: String(f.get("name")),
+      relationship: String(f.get("relationship")),
+      birthDate: String(f.get("birthDate")),
+      birthTimeStatus: String(
+        f.get("birthTimeStatus"),
+      ) as Person["birthTimeStatus"],
+      birthplace: String(f.get("birthplace")),
+      notes: String(f.get("notes")),
+    });
+    track(existing ? "person_updated" : "person_created", {
+      relationship_type: String(f.get("relationship")),
+      birth_time_quality: String(f.get("birthTimeStatus")),
+    });
+    nav("/people");
+  }
+  return (
+    <AppShell>
+      <Page
+        eyebrow={existing ? "EDIT PROFILE" : "ADD SOMEONE"}
+        title={existing ? existing.name : "Who are we looking at?"}
+      />
+      <form className="stack-form" onSubmit={submit}>
+        <label>
+          Private name or alias
+          <input name="name" defaultValue={existing?.name} required />
+        </label>
+        <label>
+          Relationship
+          <select name="relationship" defaultValue={existing?.relationship}>
+            <option>Partner</option>
+            <option>Crush</option>
+            <option>Ex</option>
+            <option>Friend</option>
+            <option>Custom</option>
+          </select>
+        </label>
+        <label>
+          Date of birth
+          <input
+            name="birthDate"
+            type="date"
+            defaultValue={existing?.birthDate}
+            required
+          />
+        </label>
+        <fieldset>
+          <legend>Birth time</legend>
+          <div className="choice-row">
+            {["exact", "approximate", "unknown"].map((x) => (
+              <label key={x}>
+                <input
+                  type="radio"
+                  name="birthTimeStatus"
+                  value={x}
+                  defaultChecked={
+                    (existing?.birthTimeStatus ?? "unknown") === x
+                  }
+                />
+                {x}
+              </label>
+            ))}
+          </div>
+          <small>
+            Without an exact time, house and ascendant interpretations may be
+            less precise.
+          </small>
+        </fieldset>
+        <label>
+          Birthplace
+          <input
+            name="birthplace"
+            defaultValue={existing?.birthplace}
+            placeholder="City, country"
+            required
+          />
+          <small>
+            Manual entry for now. Confirm the normalized place when lookup is
+            connected.
+          </small>
+        </label>
+        <label>
+          Notes <span>optional</span>
+          <textarea name="notes" defaultValue={existing?.notes} />
+        </label>
+        <div className="notice">
+          <LockKeyhole />
+          This person is not notified. Avoid sensitive information without their
+          permission.
+        </div>
+        <button className="button">Save private profile</button>
+      </form>
+    </AppShell>
+  );
+}
+function Empty({
+  icon,
+  title,
+  text,
+  action,
+  to,
+}: {
+  icon: ReactNode;
+  title: string;
+  text: string;
+  action: string;
+  to: string;
+}) {
+  return (
+    <div className="empty">
+      {icon}
+      <h2>{title}</h2>
+      <p>{text}</p>
+      <ButtonLink to={to}>{action}</ButtonLink>
+    </div>
+  );
+}
+export function Matches() {
+  return (
+    <AppShell>
+      <Page
+        eyebrow="CONNECTIONS"
+        title="Your matches"
+        action={
+          <Link className="icon-button" to="/matches/new">
+            <Plus />
+          </Link>
+        }
+      />
+      <div className="list">
+        <Link className="match-card" to="/matches/demo/report">
+          <div>
+            <span>A</span>
+            <span>M</span>
+          </div>
+          <section>
+            <small>OVERALL COMPATIBILITY</small>
+            <h3>You + Maya</h3>
+            <p>Communication · Attraction · Emotional rhythm</p>
+          </section>
+          <strong>82</strong>
+        </Link>
+      </div>
+      <p className="fixture-note">Preview report · illustrative data</p>
+    </AppShell>
+  );
+}
+export function NewMatch() {
+  const [phase, setPhase] = useState("");
+  const nav = useNavigate();
+  function generate(e: FormEvent) {
+    e.preventDefault();
+    track("match_generation_requested");
+    const phases = [
+      "Preparing both charts",
+      "Comparing placements",
+      "Finding major themes",
+      "Writing your report",
+    ];
+    let i = 0;
+    setPhase(phases[0]);
+    const timer = setInterval(() => {
+      i++;
+      if (i === phases.length) {
+        clearInterval(timer);
+        track("match_generation_completed", {
+          focus: "overall",
+          birth_data_quality: "mixed",
+        });
+        nav("/matches/demo/report");
+      } else setPhase(phases[i]);
+    }, 650);
+  }
+  return (
+    <AppShell>
+      <Page eyebrow="NEW MATCH" title="Explore a connection" />
+      <form className="stack-form" onSubmit={generate}>
+        <label>
+          Your profile
+          <select>
+            <option>Deepak · birth profile</option>
+          </select>
+        </label>
+        <label>
+          The other person
+          <select required>
+            <option value="">Choose a private profile</option>
+            {peopleStore.list().map((p) => (
+              <option key={p.id}>{p.name}</option>
+            ))}
+            <option>Maya · preview</option>
+          </select>
+        </label>
+        <fieldset>
+          <legend>What do you want to understand?</legend>
+          <div className="radio-stack">
+            {[
+              "Overall compatibility",
+              "Attraction",
+              "Emotional compatibility",
+              "Communication",
+              "Conflict patterns",
+              "Long-term potential",
+            ].map((x, i) => (
+              <label key={x}>
+                <input type="radio" name="focus" defaultChecked={!i} />
+                <span>{x}</span>
+                <Circle />
+              </label>
+            ))}
+          </div>
+        </fieldset>
+        <div className="notice">
+          <Sparkles />
+          One profile has an unknown birth time. We’ll avoid house-based
+          certainty and label the report’s confidence.
+        </div>
+        <button className="button">Generate report</button>
+        {phase && (
+          <div className="generation" role="status" aria-live="polite">
+            <span />
+            <p>{phase}</p>
+          </div>
+        )}
+      </form>
+    </AppShell>
+  );
+}
+export function Report() {
+  const sections = [
+    [
+      "Strongest connection",
+      "You make it easier for each other to name what usually stays unspoken. Curiosity is a shared love language here.",
+    ],
+    [
+      "Primary friction",
+      "One of you reaches for clarity while the other needs room. The pattern works best when space has a clear return point.",
+    ],
+    [
+      "Attraction",
+      "Warmth and intrigue arrive together. Venus–Mars contact suggests a lively pull, while Mercury keeps attraction mentally engaged.",
+    ],
+    [
+      "Emotional rhythm",
+      "There is genuine recognition, though your nervous systems may move at different speeds. Neither pace is the “right” one.",
+    ],
+    [
+      "Communication",
+      "Direct questions help. Assumptions do not. A strong Mercury link supports repair when both people stay specific.",
+    ],
+    [
+      "Conflict and repair",
+      "Pause before solving. Name the feeling, then the request. This connection benefits from structure after intensity.",
+    ],
+    [
+      "Long-term tendencies",
+      "Shared growth is possible when independence is treated as part of intimacy—not evidence against it.",
+    ],
+  ];
+  return (
+    <AppShell>
+      <Page eyebrow="COMPATIBILITY REPORT" title="You + Maya" />
+      <div className="report-score">
+        <div>
+          <small>OVERALL</small>
+          <strong>82</strong>
+          <span>/100</span>
+        </div>
+        <section>
+          <span className="quality">MODERATE CONFIDENCE</span>
+          <h2>A bond built on candor</h2>
+          <p>Strong mutual recognition with different emotional pacing.</p>
+        </section>
+      </div>
+      <div className="score-strip">
+        {[
+          ["Attraction", 88],
+          ["Emotional", 76],
+          ["Communication", 84],
+          ["Long-term", 78],
+        ].map(([x, n]) => (
+          <div key={x}>
+            <span>{x}</span>
+            <b>{n}</b>
+            <i style={{ width: `${n}%` }} />
+          </div>
+        ))}
+      </div>
+      <div className="report-body">
+        {sections.map(([title, text], i) => (
+          <section key={title}>
+            <span>0{i + 1}</span>
+            <div>
+              <h2>{title}</h2>
+              <p>{text}</p>
+            </div>
+          </section>
+        ))}
+        <section>
+          <span>08</span>
+          <div>
+            <h2>Reflection prompts</h2>
+            <ul>
+              <li>What does reassurance look like to each of you?</li>
+              <li>How can you ask for space without creating ambiguity?</li>
+              <li>
+                Which differences feel generative rather than threatening?
+              </li>
+            </ul>
+          </div>
+        </section>
+        <section>
+          <span>09</span>
+          <div>
+            <h2>Astrological basis</h2>
+            <p>
+              Venus trine Mars · Mercury sextile Mercury · Moon square Saturn.
+              Birth-time uncertainty limits house and ascendant interpretation.
+            </p>
+          </div>
+        </section>
+      </div>
+      <div className="report-actions">
+        <ButtonLink to="/ask">Ask about this match</ButtonLink>
+        <button className="button secondary">
+          <Bookmark /> Save
+        </button>
+        <button className="button secondary">
+          <Download /> Share card
+        </button>
+      </div>
+      <Disclaimer />
+    </AppShell>
+  );
+}
+export function Ask() {
+  const prompts = [
+    "Why do I lose interest once someone likes me?",
+    "What creates the strongest attraction between us?",
+    "Where might our communication break down?",
+  ];
+  const [messages, setMessages] = useState<
+    { role: "me" | "astro"; text: string }[]
+  >([]);
+  const [text, setText] = useState("");
+  const [waiting, setWaiting] = useState(false);
+  useEffect(() => track("ask_screen_viewed"), []);
+  function submit(e: FormEvent) {
+    e.preventDefault();
+    if (!text.trim()) return;
+    const q = text;
+    setMessages((m) => [...m, { role: "me", text: q }]);
+    setText("");
+    setWaiting(true);
+    track("astrology_question_submitted", { context_type: "love_life" });
+    setTimeout(() => {
+      setMessages((m) => [
+        ...m,
+        {
+          role: "astro",
+          text: "Your chart suggests that attraction can feel safest while it remains open-ended. When interest becomes certain, closeness may bring old questions about autonomy to the surface. This is a pattern to notice—not a verdict. [Venus–Uranus; Moon–Saturn]",
+        },
+      ]);
+      setWaiting(false);
+      track("astrology_answer_completed", { context_type: "love_life" });
+    }, 900);
+  }
+  return (
+    <AppShell>
+      <div className="chat">
+        <Page eyebrow="A PRIVATE CONVERSATION" title="Ask AstroMatch" />
+        <div className="mode-row">
+          <button className="active">My love life</button>
+          <button>This match</button>
+          <button>Communication</button>
+        </div>
+        <div className="messages" aria-live="polite">
+          {!messages.length && (
+            <div className="chat-intro">
+              <Sparkles />
+              <h2>What are you trying to understand?</h2>
+              <p>
+                Ask about a pattern, a connection or the part you can’t quite
+                name.
+              </p>
+              <div>
+                {prompts.map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => {
+                      setText(p);
+                      track("suggested_question_clicked", {
+                        category: "love_life",
+                      });
+                    }}
+                  >
+                    {p}
+                    <ArrowRight />
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          {messages.map((m, i) => (
+            <div key={i} className={`message ${m.role}`}>
+              {m.role === "astro" && <small>ASTROMATCH · INTERPRETATION</small>}
+              <p>{m.text}</p>
+              {m.role === "astro" && (
+                <div className="feedback">
+                  <span>Was this helpful?</span>
+                  <button>Yes</button>
+                  <button>Not quite</button>
+                </div>
+              )}
+            </div>
+          ))}
+          {waiting && (
+            <div className="thinking">
+              <i />
+              <i />
+              <i /> Waking AstroMatch up…
+            </div>
+          )}
+        </div>
+        <form className="composer" onSubmit={submit}>
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={1}
+            placeholder="Ask what’s on your mind…"
+            aria-label="Your question"
+          />
+          <button disabled={!text.trim() || waiting} aria-label="Send">
+            <Send />
+          </button>
+        </form>
+      </div>
+    </AppShell>
+  );
+}
+export function Saved() {
+  return (
+    <AppShell>
+      <Page eyebrow="YOUR LIBRARY" title="Saved" />
+      <div className="tabs">
+        <button className="active">Reports</button>
+        <button>Conversations</button>
+        <button>Share cards</button>
+      </div>
+      <Empty
+        icon={<Bookmark />}
+        title="Keep the useful parts close"
+        text="Reports and conversations you save will live here."
+        action="Explore a match"
+        to="/matches"
+      />
+    </AppShell>
+  );
+}
+export function Settings() {
+  const [consent, setConsent] = useState(
+    localStorage.getItem("am:analytics-consent") === "granted",
+  );
+  return (
+    <AppShell>
+      <div className="settings-profile-shell">
+        <Page eyebrow="YOUR ACCOUNT" title="Settings" />
+        <ProfileTabs />
+        <div className="settings-list">
+          <section>
+            <h2>Privacy</h2>
+            <label className="toggle">
+              Anonymous product analytics
+              <input
+                type="checkbox"
+                checked={consent}
+                onChange={(e) => {
+                  setConsent(e.target.checked);
+                  setAnalyticsConsent(e.target.checked);
+                }}
+              />
+              <i />
+            </label>
+            <p>
+              Never includes names, email, birth data, locations or question
+              text.
+            </p>
+          </section>
+          <section>
+            <h2>Dating profile</h2>
+            <button disabled>
+              Photos <span>Backend support needed</span>
+            </button>
+            <button disabled>
+              Prompts and answers <span>Backend support needed</span>
+            </button>
+            <button disabled>
+              Discovery preferences <span>Backend support needed</span>
+            </button>
+          </section>
+          <section>
+            <h2>Account</h2>
+            <button>
+              Export my data <span>Coming soon</span>
+            </button>
+            <button>
+              Notifications <span>Coming soon</span>
+            </button>
+            <button
+              onClick={async () => {
+                await auth?.signOut();
+                track("logout_completed");
+              }}
+            >
+              Log out
+            </button>
+            <button className="danger">Delete account</button>
+          </section>
+          <section>
+            <h2>Legal</h2>
+            <Link to="/privacy">
+              Privacy policy <ChevronRight />
+            </Link>
+            <Link to="/terms">
+              Terms of use <ChevronRight />
+            </Link>
+          </section>
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+function Onboarding() {
+  const nav = useNavigate();
+  const [account, setAccount] = useState<AccountState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState("");
 
-  useEffect(()=>{
-    let active=true;
-    accountApi.get()
-      .then(current=>{
-        if(!active)return;
-        if(current.onboarding_completed){nav('/home',{replace:true});return}
+  useEffect(() => {
+    let active = true;
+    accountApi
+      .get()
+      .then((current) => {
+        if (!active) return;
+        if (current.onboarding_completed) {
+          nav("/home", { replace: true });
+          return;
+        }
         setAccount(current);
       })
-      .catch(()=>active&&setMessage('We couldn’t load your account. Please sign in again.'))
-      .finally(()=>active&&setLoading(false));
-    return()=>{active=false};
-  },[nav]);
+      .catch(
+        () =>
+          active &&
+          setMessage("We couldn’t load your account. Please sign in again."),
+      )
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+    };
+  }, [nav]);
 
-  async function refreshAccount(){
-    const current=await accountApi.get();
+  async function refreshAccount() {
+    const current = await accountApi.get();
     setAccount(current);
-    const route=routeForAccount(current);
-    if(route==='/home')track('onboarding_completed');
-    nav(route,{replace:true});
+    const route = routeForAccount(current);
+    if (route === "/home") track("onboarding_completed");
+    nav(route, { replace: true });
   }
 
-  async function submitProfile(e:FormEvent<HTMLFormElement>){
+  async function submitProfile(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setLoading(true);
-    setMessage('');
-    const form=new FormData(e.currentTarget);
-    const profile:ProfileInput={
-      preferred_name:String(form.get('preferred_name')).trim(),
-      gender:String(form.get('gender')).trim()||null,
-      pronouns:String(form.get('pronouns')).trim()||null,
-      date_of_birth:String(form.get('date_of_birth')),
+    setMessage("");
+    const form = new FormData(e.currentTarget);
+    const profile: ProfileInput = {
+      preferred_name: String(form.get("preferred_name")).trim(),
+      gender: String(form.get("gender")).trim() || null,
+      pronouns: String(form.get("pronouns")).trim() || null,
+      date_of_birth: String(form.get("date_of_birth")),
     };
-    try{
+    try {
       await accountApi.updateProfile(profile);
       await accountApi.completeProfile(profile);
       await refreshAccount();
-    }catch(error){
-      setMessage(apiFormMessage(error,'We couldn’t save your profile. Check each field and try again.'));
-    }finally{
+    } catch (error) {
+      setMessage(
+        apiFormMessage(
+          error,
+          "We couldn’t save your profile. Check each field and try again.",
+        ),
+      );
+    } finally {
       setLoading(false);
     }
   }
 
-  async function submitBirthProfile(e:FormEvent<HTMLFormElement>){
+  async function submitBirthProfile(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setLoading(true);
-    setMessage('');
-    const form=new FormData(e.currentTarget);
-    const timeStatus=String(form.get('birth_time_status')) as BirthProfileInput['birth_time_precision'];
-    const hour=String(form.get('birth_hour'));
-    const minute=String(form.get('birth_minute'));
-    const time=timeStatus==='unknown'?'':`${hour}:${minute}`;
-    const birthProfile:BirthProfileInput={
-      display_name:String(form.get('display_name')).trim(),
-      relationship_type:String(form.get('relationship_type')) as BirthProfileInput['relationship_type'],
-      birth_date:String(form.get('birth_date')),
-      birth_time:timeStatus==='unknown'||!time?null:time,
-      birth_time_precision:timeStatus,
-      timezone:normalizeTimezone(String(form.get('timezone')).trim()),
-      country:String(form.get('country')).trim().toUpperCase(),
-      city:String(form.get('city')).trim(),
-      latitude:Number(form.get('latitude')),
-      longitude:Number(form.get('longitude')),
-      is_primary:true,
-      notes:null,
+    setMessage("");
+    const form = new FormData(e.currentTarget);
+    const timeStatus = String(
+      form.get("birth_time_status"),
+    ) as BirthProfileInput["birth_time_precision"];
+    const hour = String(form.get("birth_hour"));
+    const minute = String(form.get("birth_minute"));
+    const time = timeStatus === "unknown" ? "" : `${hour}:${minute}`;
+    const birthProfile: BirthProfileInput = {
+      display_name: String(form.get("display_name")).trim(),
+      relationship_type: String(
+        form.get("relationship_type"),
+      ) as BirthProfileInput["relationship_type"],
+      birth_date: String(form.get("birth_date")),
+      birth_time: timeStatus === "unknown" || !time ? null : time,
+      birth_time_precision: timeStatus,
+      timezone: normalizeTimezone(String(form.get("timezone")).trim()),
+      country: String(form.get("country")).trim().toUpperCase(),
+      city: String(form.get("city")).trim(),
+      latitude: Number(form.get("latitude")),
+      longitude: Number(form.get("longitude")),
+      is_primary: true,
+      notes: null,
     };
-    try{
+    try {
       await birthProfilesApi.create(birthProfile);
       await accountApi.get();
-      track('onboarding_completed');
-      nav('/profile?onboarding=dating-profile',{replace:true});
-    }catch(error){
-      setMessage(apiFormMessage(error,'We couldn’t create your birth profile. Check the place and time details, then retry.'));
-    }finally{
+      track("onboarding_completed");
+      nav("/profile?onboarding=dating-profile", { replace: true });
+    } catch (error) {
+      setMessage(
+        apiFormMessage(
+          error,
+          "We couldn’t create your birth profile. Check the place and time details, then retry.",
+        ),
+      );
+    } finally {
       setLoading(false);
     }
   }
 
-  if(loading&&!account)return <div className="onboarding"><header><Brand/><span>SYNCING</span></header><main><p role="status">Preparing your private account…</p></main></div>;
-  const birthStep=account?.next_step==='create_birth_profile'||account?.profile_status==='profile_complete';
-  const profile=account?.profile;
+  if (loading && !account)
+    return (
+      <div className="onboarding">
+        <header>
+          <Brand />
+          <span>SYNCING</span>
+        </header>
+        <main>
+          <p role="status">Preparing your private account…</p>
+        </main>
+      </div>
+    );
+  const birthStep =
+    account?.next_step === "create_birth_profile" ||
+    account?.profile_status === "profile_complete";
+  const profile = account?.profile;
 
-  return <div className="onboarding"><header><Brand/><span>{birthStep?'02 / 03':'01 / 03'}</span></header><main><p className="eyebrow">{birthStep?'YOUR BIRTH CHART':'LET’S BEGIN'}</p><h1>{birthStep?'The details the sky remembers.':'Make this space yours.'}</h1>{message&&<p role="alert" className="form-message">{message}</p>}{birthStep?<BirthProfileForm loading={loading} profile={profile} onSubmit={submitBirthProfile}/>:<form className="stack-form" onSubmit={submitProfile}><label>What should we call you?<input name="preferred_name" defaultValue={profile?.preferred_name??auth?.currentUser?.displayName??''} required/></label><label>Email<input type="email" value={auth?.currentUser?.email??''} readOnly aria-readonly="true"/><small>Managed securely by your sign-in provider.</small></label><label>Date of birth<input name="date_of_birth" type="date" defaultValue={profile?.date_of_birth??''} required/></label><div className="onboarding-pair"><label>Gender<select name="gender" defaultValue={profile?.gender??''}><option value="">Prefer not to say</option><option value="woman">Woman</option><option value="man">Man</option><option value="non_binary">Non-binary</option><option value="self_described">Self-described</option></select></label><label>Pronouns<input name="pronouns" defaultValue={profile?.pronouns??''} placeholder="e.g. she/her"/></label></div><button className="button" disabled={loading}>{loading?'Saving…':'Continue'} <ArrowRight/></button></form>}</main></div>
+  return (
+    <div className="onboarding">
+      <header>
+        <Brand />
+        <span>{birthStep ? "02 / 03" : "01 / 03"}</span>
+      </header>
+      <main>
+        <p className="eyebrow">
+          {birthStep ? "YOUR BIRTH CHART" : "LET’S BEGIN"}
+        </p>
+        <h1>
+          {birthStep
+            ? "The details the sky remembers."
+            : "Make this space yours."}
+        </h1>
+        {message && (
+          <p role="alert" className="form-message">
+            {message}
+          </p>
+        )}
+        {birthStep ? (
+          <BirthProfileForm
+            loading={loading}
+            profile={profile}
+            onSubmit={submitBirthProfile}
+          />
+        ) : (
+          <form className="stack-form" onSubmit={submitProfile}>
+            <label>
+              What should we call you?
+              <input
+                name="preferred_name"
+                defaultValue={
+                  profile?.preferred_name ??
+                  auth?.currentUser?.displayName ??
+                  ""
+                }
+                required
+              />
+            </label>
+            <label>
+              Email
+              <input
+                type="email"
+                value={auth?.currentUser?.email ?? ""}
+                readOnly
+                aria-readonly="true"
+              />
+              <small>Managed securely by your sign-in provider.</small>
+            </label>
+            <label>
+              Date of birth
+              <input
+                name="date_of_birth"
+                type="date"
+                defaultValue={profile?.date_of_birth ?? ""}
+                required
+              />
+            </label>
+            <div className="onboarding-pair">
+              <label>
+                Gender
+                <select name="gender" defaultValue={profile?.gender ?? ""}>
+                  <option value="">Prefer not to say</option>
+                  <option value="woman">Woman</option>
+                  <option value="man">Man</option>
+                  <option value="non_binary">Non-binary</option>
+                  <option value="self_described">Self-described</option>
+                </select>
+              </label>
+              <label>
+                Pronouns
+                <input
+                  name="pronouns"
+                  defaultValue={profile?.pronouns ?? ""}
+                  placeholder="e.g. she/her"
+                />
+              </label>
+            </div>
+            <button className="button" disabled={loading}>
+              {loading ? "Saving…" : "Continue"} <ArrowRight />
+            </button>
+          </form>
+        )}
+      </main>
+    </div>
+  );
 }
-export function App(){return <><PageTracker/><Routes><Route path="/" element={<Landing/>}/><Route path="/about" element={<Legal kind="about"/>}/><Route path="/privacy" element={<Legal kind="privacy"/>}/><Route path="/terms" element={<Legal kind="terms"/>}/><Route path="/login" element={<AuthPage/>}/><Route path="/signup" element={<AuthPage signup/>}/><Route path="/onboarding/*" element={<Onboarding/>}/><Route path="/home" element={<Dashboard/>}/><Route path="/today" element={<Navigate to="/home" replace/>}/><Route path="/blueprint" element={<Protected><BlueprintPage/></Protected>}/><Route path="/ask" element={<Ask/>}/><Route path="/relationships" element={<Protected><RelationshipsPage/></Protected>}/><Route path="/relationships/new" element={<Protected><NewRelationshipPage/></Protected>}/><Route path="/relationships/:relationshipId" element={<Protected><RelationshipPage/></Protected>}/><Route path="/relationships/:relationshipId/report" element={<Protected><RelationshipReportPage/></Protected>}/><Route path="/matches" element={<Navigate to="/relationships" replace/>}/><Route path="/matches/new" element={<Navigate to="/relationships/new" replace/>}/><Route path="/matches/:matchId" element={<LegacyRelationshipRedirect/>}/><Route path="/matches/:matchId/report" element={<LegacyRelationshipRedirect report/>}/><Route path="/people" element={<Protected><PeoplePage/></Protected>}/><Route path="/people/new" element={<Protected><PersonPage/></Protected>}/><Route path="/people/:personId" element={<Protected><PersonPage/></Protected>}/><Route path="/people/:personId/edit" element={<Protected><PersonPage/></Protected>}/><Route path="/saved" element={<Saved/>}/><Route path="/profile" element={<DatingProfilePage/>}/><Route path="/me" element={<Navigate to="/profile" replace/>}/><Route path="/profile/chart" element={<ChartPage/>}/><Route path="/profile/chart/:birthProfileId" element={<ChartPage/>}/><Route path="/profile/:birthProfileId" element={<ChartPage/>}/><Route path="/settings" element={<Settings/>}/><Route path="*" element={<Navigate to="/" replace/>}/></Routes></>}
+export function App() {
+  return (
+    <>
+      <PageTracker />
+      <Routes>
+        <Route path="/" element={<Landing />} />
+        <Route path="/about" element={<Legal kind="about" />} />
+        <Route path="/privacy" element={<Legal kind="privacy" />} />
+        <Route path="/terms" element={<Legal kind="terms" />} />
+        <Route path="/login" element={<AuthPage />} />
+        <Route path="/signup" element={<AuthPage signup />} />
+        <Route path="/onboarding/*" element={<Onboarding />} />
+        <Route
+          path="/home"
+          element={
+            <Protected>
+              <Dashboard />
+            </Protected>
+          }
+        />
+        <Route path="/today" element={<Navigate to="/home" replace />} />
+        <Route
+          path="/blueprint"
+          element={
+            <Protected>
+              <BlueprintPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/ask"
+          element={
+            <Protected>
+              <AskPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/relationships"
+          element={
+            <Protected>
+              <RelationshipsPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/relationships/new"
+          element={
+            <Protected>
+              <NewRelationshipPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/relationships/:relationshipId"
+          element={
+            <Protected>
+              <RelationshipPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/relationships/:relationshipId/report"
+          element={
+            <Protected>
+              <RelationshipReportPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/matches"
+          element={<Navigate to="/relationships" replace />}
+        />
+        <Route
+          path="/matches/new"
+          element={<Navigate to="/relationships/new" replace />}
+        />
+        <Route
+          path="/matches/:matchId"
+          element={<LegacyRelationshipRedirect />}
+        />
+        <Route
+          path="/matches/:matchId/report"
+          element={<LegacyRelationshipRedirect report />}
+        />
+        <Route
+          path="/people"
+          element={
+            <Protected>
+              <PeoplePage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/people/new"
+          element={
+            <Protected>
+              <PersonPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/people/:personId"
+          element={
+            <Protected>
+              <PersonPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/people/:personId/edit"
+          element={
+            <Protected>
+              <PersonPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/saved"
+          element={
+            <Protected>
+              <SavedPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/profile"
+          element={
+            <Protected>
+              <DatingProfilePage />
+            </Protected>
+          }
+        />
+        <Route path="/me" element={<Navigate to="/profile" replace />} />
+        <Route
+          path="/profile/chart"
+          element={
+            <Protected>
+              <ChartPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/profile/chart/:birthProfileId"
+          element={
+            <Protected>
+              <ChartPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/profile/:birthProfileId"
+          element={
+            <Protected>
+              <ChartPage />
+            </Protected>
+          }
+        />
+        <Route
+          path="/settings"
+          element={
+            <Protected>
+              <SettingsPage />
+            </Protected>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </>
+  );
+}
 
-function LegacyRelationshipRedirect({report=false}:{report?:boolean}){const {matchId}=useParams();return <Navigate to={`/relationships/${matchId}${report?'/report':''}`} replace/>}
-function Protected({children}:{children:ReactNode}){
-  const location=useLocation();
-  const [checked,setChecked]=useState(!auth);
-  const [signedIn,setSignedIn]=useState(Boolean(auth?.currentUser));
-  useEffect(()=>{
-    let unsubscribe=()=>{};
-    const authInstance=auth;
-    if(authInstance)void import('firebase/auth').then(({onAuthStateChanged})=>{unsubscribe=onAuthStateChanged(authInstance,user=>{setSignedIn(Boolean(user));setChecked(true)})});
-    let robots=document.querySelector<HTMLMetaElement>('meta[name="robots"]');
-    const existed=Boolean(robots);
-    const previous=robots?.content;
-    if(!robots){robots=document.createElement('meta');robots.name='robots';document.head.appendChild(robots)}
-    robots.content='noindex,nofollow';
-    return()=>{unsubscribe();if(!existed)robots?.remove();else if(robots&&previous!==undefined)robots.content=previous};
-  },[]);
-  if(!checked)return <div className="generation" role="status"><span/><p>Opening your private space…</p></div>;
-  if(!signedIn)return <Navigate to="/login" state={{from:location.pathname}} replace/>;
+function LegacyRelationshipRedirect({ report = false }: { report?: boolean }) {
+  const { matchId } = useParams();
+  return (
+    <Navigate
+      to={`/relationships/${matchId}${report ? "/report" : ""}`}
+      replace
+    />
+  );
+}
+function Protected({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const [checked, setChecked] = useState(!auth);
+  const [signedIn, setSignedIn] = useState(Boolean(auth?.currentUser));
+  useEffect(() => {
+    let unsubscribe = () => {};
+    const authInstance = auth;
+    if (authInstance)
+      void import("firebase/auth").then(({ onAuthStateChanged }) => {
+        unsubscribe = onAuthStateChanged(authInstance, (user) => {
+          setSignedIn(Boolean(user));
+          setChecked(true);
+        });
+      });
+    let robots = document.querySelector<HTMLMetaElement>('meta[name="robots"]');
+    const existed = Boolean(robots);
+    const previous = robots?.content;
+    if (!robots) {
+      robots = document.createElement("meta");
+      robots.name = "robots";
+      document.head.appendChild(robots);
+    }
+    robots.content = "noindex,nofollow";
+    return () => {
+      unsubscribe();
+      if (!existed) robots?.remove();
+      else if (robots && previous !== undefined) robots.content = previous;
+    };
+  }, []);
+  if (!checked)
+    return (
+      <div className="generation" role="status">
+        <span />
+        <p>Opening your private space…</p>
+      </div>
+    );
+  if (!signedIn)
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />;
   return children;
 }

--- a/src/ConnectedPages.tsx
+++ b/src/ConnectedPages.tsx
@@ -1,0 +1,472 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { ArrowRight, Bookmark, Send, Sparkles, Trash2 } from "lucide-react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { AppShell, ButtonLink, Page } from "./components";
+import { ApiError } from "./lib/api";
+import { auth } from "./lib/firebase";
+import { accountApi } from "./lib/account";
+import {
+  conversationsApi,
+  type ConversationContext,
+  type ConversationMessage,
+} from "./lib/conversations";
+import { libraryApi, type Library } from "./lib/library";
+import { relationshipsApi, type Relationship } from "./lib/relationships";
+import { setAnalyticsConsent, track } from "./lib/analytics";
+import { ProfileTabs } from "./ProfileTabs";
+
+const message = (error: unknown) =>
+  error instanceof ApiError
+    ? error.message
+    : "AstroMatch could not connect. Please try again.";
+
+export function AskPage() {
+  const [params, setParams] = useSearchParams();
+  const requestedRelationship = params.get("relationshipId") ?? "";
+  const requestedConversation = params.get("conversationId") ?? "";
+  const [relationships, setRelationships] = useState<Relationship[]>([]);
+  const [context, setContext] = useState<ConversationContext>(
+    requestedRelationship ? "relationship" : "personal",
+  );
+  const [relationshipId, setRelationshipId] = useState(requestedRelationship);
+  const [conversationId, setConversationId] = useState(requestedConversation);
+  const [messages, setMessages] = useState<ConversationMessage[]>([]);
+  const [text, setText] = useState("");
+  const [waiting, setWaiting] = useState(false);
+  const [error, setError] = useState("");
+  useEffect(() => {
+    track("ask_screen_viewed");
+    relationshipsApi
+      .all()
+      .then(setRelationships)
+      .catch(() => setRelationships([]));
+  }, []);
+  useEffect(() => {
+    if (!requestedConversation) return;
+    conversationsApi
+      .get(requestedConversation)
+      .then((value) => {
+        setConversationId(value.conversation.id);
+        setContext(value.conversation.contextType);
+        setRelationshipId(value.conversation.relationshipId ?? "");
+        setMessages(value.messages);
+      })
+      .catch((value) => setError(message(value)));
+  }, [requestedConversation]);
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const question = text.trim();
+    if (!question || waiting) return;
+    if (context === "relationship" && !relationshipId) {
+      setError("Choose a relationship first.");
+      return;
+    }
+    setWaiting(true);
+    setError("");
+    setMessages((items) => [
+      ...items,
+      { id: crypto.randomUUID(), role: "user", content: question },
+    ]);
+    setText("");
+    track("astrology_question_submitted", { context_type: context });
+    try {
+      let id = conversationId;
+      if (!id) {
+        const created = await conversationsApi.create({
+          contextType: context,
+          relationshipId: context === "relationship" ? relationshipId : null,
+          title: question.slice(0, 80),
+        });
+        id = created.id;
+        setConversationId(id);
+        setParams({ conversationId: id }, { replace: true });
+      }
+      const answer = await conversationsApi.send(id, question);
+      setMessages((items) => [...items, answer]);
+      track("astrology_answer_completed", { context_type: context });
+    } catch (value) {
+      setError(message(value));
+      track("astrology_answer_failed", {
+        context_type: context,
+        error_category: value instanceof ApiError ? value.code : "network",
+      });
+    } finally {
+      setWaiting(false);
+    }
+  }
+  function reset(next: ConversationContext) {
+    setContext(next);
+    setConversationId("");
+    setMessages([]);
+    setParams({});
+    setError("");
+  }
+  return (
+    <AppShell>
+      <div className="chat">
+        <Page eyebrow="A PRIVATE CONVERSATION" title="Ask AstroMatch" />
+        <div className="mode-row">
+          <button
+            className={context === "personal" ? "active" : ""}
+            onClick={() => reset("personal")}
+          >
+            My patterns
+          </button>
+          <button
+            className={context === "relationship" ? "active" : ""}
+            onClick={() => reset("relationship")}
+          >
+            A relationship
+          </button>
+          <button
+            className={context === "general" ? "active" : ""}
+            onClick={() => reset("general")}
+          >
+            General
+          </button>
+        </div>
+        {context === "relationship" && (
+          <label className="chat-context">
+            Relationship
+            <select
+              value={relationshipId}
+              disabled={Boolean(conversationId)}
+              onChange={(event) => setRelationshipId(event.target.value)}
+            >
+              <option value="">Choose a relationship</option>
+              {relationships
+                .filter(
+                  (item) => item.compatibilityStatus === "compatibility_ready",
+                )
+                .map((item) => (
+                  <option value={item.id} key={item.id}>
+                    {item.title ??
+                      item.person?.displayName ??
+                      "Private relationship"}
+                  </option>
+                ))}
+            </select>
+          </label>
+        )}
+        <div className="messages" aria-live="polite">
+          {!messages.length && (
+            <div className="chat-intro">
+              <Sparkles />
+              <h2>What are you trying to understand?</h2>
+              <p>
+                Answers use only the chart or relationship context you
+                deliberately select.
+              </p>
+            </div>
+          )}
+          {messages.map((item) => (
+            <div
+              key={item.id}
+              className={`message ${item.role === "user" ? "me" : "astro"}`}
+            >
+              {item.role === "assistant" && (
+                <small>ASTROMATCH · INTERPRETATION</small>
+              )}
+              <p>{item.content}</p>
+              {item.assistantPayload?.reflectionPrompts.map((prompt) => (
+                <p className="reflection" key={prompt}>
+                  {prompt}
+                </p>
+              ))}
+              {item.assistantPayload?.limitations.map((limit) => (
+                <small key={limit}>{limit}</small>
+              ))}
+              {item.role === "assistant" && (
+                <div className="feedback">
+                  <span>Was this helpful?</span>
+                  <button
+                    onClick={() =>
+                      void conversationsApi.feedback(item.id, "helpful")
+                    }
+                  >
+                    Yes
+                  </button>
+                  <button
+                    onClick={() =>
+                      void conversationsApi.feedback(item.id, "not_helpful")
+                    }
+                  >
+                    Not quite
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+          {waiting && (
+            <div className="thinking">
+              <i />
+              <i />
+              <i /> Reading the selected context…
+            </div>
+          )}
+          {error && (
+            <p role="alert" className="form-message">
+              {error}
+            </p>
+          )}
+        </div>
+        <form className="composer" onSubmit={submit}>
+          <textarea
+            maxLength={2000}
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+            rows={1}
+            placeholder="Ask what’s on your mind…"
+            aria-label="Your question"
+          />
+          <button disabled={!text.trim() || waiting} aria-label="Send">
+            <Send />
+          </button>
+        </form>
+      </div>
+    </AppShell>
+  );
+}
+
+export function SavedPage() {
+  const [library, setLibrary] = useState<Library | null>(null);
+  const [error, setError] = useState("");
+  const [tab, setTab] = useState<
+    "saved_items" | "conversations" | "share_cards"
+  >("saved_items");
+  const load = () =>
+    libraryApi
+      .get()
+      .then(setLibrary)
+      .catch((value) => setError(message(value)));
+  useEffect(() => {
+    void load();
+  }, []);
+  async function remove(id: string, kind: "saved" | "conversation" | "share") {
+    if (kind === "saved") await libraryApi.remove(id);
+    else if (kind === "conversation") await conversationsApi.archive(id);
+    else await libraryApi.revokeShare(id);
+    await load();
+  }
+  const items = library?.[tab] ?? [];
+  return (
+    <AppShell>
+      <Page eyebrow="YOUR PRIVATE LIBRARY" title="Saved" />
+      <div className="tabs">
+        <button
+          className={tab === "saved_items" ? "active" : ""}
+          onClick={() => setTab("saved_items")}
+        >
+          Saved
+        </button>
+        <button
+          className={tab === "conversations" ? "active" : ""}
+          onClick={() => setTab("conversations")}
+        >
+          Conversations
+        </button>
+        <button
+          className={tab === "share_cards" ? "active" : ""}
+          onClick={() => setTab("share_cards")}
+        >
+          Share cards
+        </button>
+      </div>
+      {error && (
+        <p role="alert" className="form-message">
+          {error}
+        </p>
+      )}
+      {!library ? (
+        <p>Opening your library…</p>
+      ) : items.length ? (
+        <div className="list">
+          {tab === "saved_items" &&
+            library.saved_items.map((item) => (
+              <article className="list-row" key={item.id}>
+                <Link
+                  to={
+                    item.item_type === "blueprint_insight"
+                      ? "/blueprint"
+                      : `/relationships/${item.relationship_id}/report`
+                  }
+                >
+                  <Bookmark />
+                  <div>
+                    <h3>{item.item_type.replaceAll("_", " ")}</h3>
+                    <p>{item.content_key ?? "Complete report"}</p>
+                  </div>
+                </Link>
+                <button
+                  aria-label="Remove saved item"
+                  onClick={() => void remove(item.id, "saved")}
+                >
+                  <Trash2 />
+                </button>
+              </article>
+            ))}
+          {tab === "conversations" &&
+            library.conversations.map((item) => (
+              <article className="list-row" key={item.id}>
+                <Link to={`/ask?conversationId=${item.id}`}>
+                  <Sparkles />
+                  <div>
+                    <h3>{item.title}</h3>
+                    <p>{item.contextType} context</p>
+                  </div>
+                </Link>
+                <button
+                  aria-label="Archive conversation"
+                  onClick={() => void remove(item.id, "conversation")}
+                >
+                  <Trash2 />
+                </button>
+              </article>
+            ))}
+          {tab === "share_cards" &&
+            library.share_cards.map((item) => (
+              <article className="list-row" key={item.id}>
+                <div>
+                  <Sparkles />
+                  <div>
+                    <h3>Private share card</h3>
+                    <p>
+                      {item.payload.strongest_category?.replaceAll("_", " ") ??
+                        "Relationship summary"}{" "}
+                      · not publicly hosted
+                    </p>
+                  </div>
+                </div>
+                <button
+                  aria-label="Revoke share card"
+                  onClick={() => void remove(item.id, "share")}
+                >
+                  <Trash2 />
+                </button>
+              </article>
+            ))}
+        </div>
+      ) : (
+        <div className="empty">
+          <Bookmark />
+          <h2>Keep the useful parts close</h2>
+          <p>
+            Your saved reports, insights, conversations and private share cards
+            will live here.
+          </p>
+          <ButtonLink to="/relationships">Explore relationships</ButtonLink>
+        </div>
+      )}
+    </AppShell>
+  );
+}
+
+export function SettingsPage() {
+  const navigate = useNavigate();
+  const [consent, setConsent] = useState(
+    localStorage.getItem("am:analytics-consent") === "granted",
+  );
+  const [busy, setBusy] = useState("");
+  const [status, setStatus] = useState("");
+  async function exportData() {
+    setBusy("export");
+    setStatus("");
+    try {
+      const data = await accountApi.exportData();
+      const url = URL.createObjectURL(
+        new Blob([JSON.stringify(data, null, 2)], { type: "application/json" }),
+      );
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `astromatch-export-${new Date().toISOString().slice(0, 10)}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+      setStatus("Your private export was downloaded.");
+    } catch (value) {
+      setStatus(message(value));
+    } finally {
+      setBusy("");
+    }
+  }
+  async function deleteAccount() {
+    if (
+      !confirm(
+        "Delete your AstroMatch account? Your account will be disabled immediately and scheduled for permanent removal.",
+      )
+    )
+      return;
+    setBusy("delete");
+    try {
+      await accountApi.deleteAccount();
+      await auth?.signOut();
+      for (const key of Object.keys(localStorage))
+        if (key.startsWith("am:")) localStorage.removeItem(key);
+      navigate("/login?deleted=1", { replace: true });
+    } catch (value) {
+      setStatus(message(value));
+      setBusy("");
+    }
+  }
+  return (
+    <AppShell>
+      <div className="settings-profile-shell">
+        <Page eyebrow="YOUR ACCOUNT" title="Settings" />
+        <ProfileTabs />
+        <div className="settings-list">
+          <section>
+            <h2>Privacy</h2>
+            <label className="toggle">
+              Anonymous product analytics
+              <input
+                type="checkbox"
+                checked={consent}
+                onChange={(event) => {
+                  setConsent(event.target.checked);
+                  setAnalyticsConsent(event.target.checked);
+                }}
+              />
+              <i />
+            </label>
+            <p>
+              Never includes names, email, birth data, locations or question
+              text.
+            </p>
+          </section>
+          <section>
+            <h2>Account</h2>
+            <button disabled={Boolean(busy)} onClick={() => void exportData()}>
+              Export my data{" "}
+              <span>{busy === "export" ? "Preparing…" : "JSON download"}</span>
+            </button>
+            <button
+              onClick={async () => {
+                await auth?.signOut();
+                track("logout_completed");
+                navigate("/login");
+              }}
+            >
+              Log out
+            </button>
+            <button
+              disabled={Boolean(busy)}
+              className="danger"
+              onClick={() => void deleteAccount()}
+            >
+              {busy === "delete" ? "Deleting…" : "Delete account"}
+            </button>
+            {status && <p role="status">{status}</p>}
+          </section>
+          <section>
+            <h2>Legal</h2>
+            <Link to="/privacy">
+              Privacy policy <ArrowRight />
+            </Link>
+            <Link to="/terms">
+              Terms of use <ArrowRight />
+            </Link>
+          </section>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/src/RelationshipPages.tsx
+++ b/src/RelationshipPages.tsx
@@ -1,254 +1,1540 @@
-import { useEffect, useState, type FormEvent, type ReactNode } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
-import { ArrowRight, ChevronDown, LockKeyhole, Plus, RefreshCw, ShieldCheck, Sparkles, Trash2 } from 'lucide-react';
-import { ApiError } from './lib/api';
-import { env } from './lib/env';
-import { track } from './lib/analytics';
-import { blueprintApi, peopleApi, relationshipsApi, type BlueprintInsight, type CompatibilityCategory, type CompatibilityFactor, type MatchFocus, type PersonInput, type PrivatePerson, type Relationship } from './lib/relationships';
-import { birthProfilesApi } from './lib/birthProfiles';
-import { accountApi } from './lib/account';
-import { AppShell, ButtonLink, Disclaimer, Page } from './components';
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  ArrowRight,
+  ChevronDown,
+  LockKeyhole,
+  Plus,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+import { ApiError } from "./lib/api";
+import { env } from "./lib/env";
+import { track } from "./lib/analytics";
+import {
+  blueprintApi,
+  peopleApi,
+  relationshipsApi,
+  type BlueprintInsight,
+  type CompatibilityCategory,
+  type CompatibilityFactor,
+  type MatchFocus,
+  type PersonInput,
+  type PrivatePerson,
+  type Relationship,
+} from "./lib/relationships";
+import { birthProfilesApi } from "./lib/birthProfiles";
+import { accountApi } from "./lib/account";
+import { libraryApi } from "./lib/library";
+import { AppShell, ButtonLink, Disclaimer, Page } from "./components";
 
-const focusOptions:[MatchFocus,string,string][]=[
-  ['general','Overall connection','A complete view of the relationship dynamic.'],
-  ['romantic','Emotional and romantic','Affection, attraction and intimacy.'],
-  ['communication','Communication','How you understand, miss and repair each other.'],
-  ['long_term','Long-term dynamics','Stability, growth and recurring patterns.'],
+const focusOptions: [MatchFocus, string, string][] = [
+  [
+    "general",
+    "Overall connection",
+    "A complete view of the relationship dynamic.",
+  ],
+  ["romantic", "Emotional and romantic", "Affection, attraction and intimacy."],
+  [
+    "communication",
+    "Communication",
+    "How you understand, miss and repair each other.",
+  ],
+  [
+    "long_term",
+    "Long-term dynamics",
+    "Stability, growth and recurring patterns.",
+  ],
 ];
 
-function useLoad<T>(loader:(signal:AbortSignal)=>Promise<T>,deps:unknown[]=[]){
-  const [data,setData]=useState<T|null>(null);
-  const [loading,setLoading]=useState(true);
-  const [error,setError]=useState('');
-  const [revision,setRevision]=useState(0);
-  useEffect(()=>{
-    const controller=new AbortController();
-    setLoading(true);setError('');
-    loader(controller.signal).then(setData).catch(value=>{
-      if((value as Error).name!=='AbortError')setError(safeMessage(value));
-    }).finally(()=>{if(!controller.signal.aborted)setLoading(false)});
-    return()=>controller.abort();
+function useLoad<T>(
+  loader: (signal: AbortSignal) => Promise<T>,
+  deps: unknown[] = [],
+) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [revision, setRevision] = useState(0);
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError("");
+    loader(controller.signal)
+      .then(setData)
+      .catch((value) => {
+        if ((value as Error).name !== "AbortError")
+          setError(safeMessage(value));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  },[revision,...deps]);
-  return {data,loading,error,retry:()=>setRevision(value=>value+1)};
+  }, [revision, ...deps]);
+  return {
+    data,
+    loading,
+    error,
+    retry: () => setRevision((value) => value + 1),
+  };
 }
 
-function safeMessage(error:unknown){
-  if(error instanceof ApiError){
-    if(error.fields&&Object.keys(error.fields).length)return Object.entries(error.fields).map(([field,message])=>`${titleCase(field)}: ${message}`).join(' · ');
-    if(error.status===409)return 'This relationship already exists or its source data changed. Refresh the relationship list and try again.';
-    if(error.status===429)return error.message||'You have reached the current generation limit.';
-    if(error.status===503)return 'The relationship service is resting for a moment. Your details are safe—please retry.';
-    if(error.status===422)return error.message;
+function safeMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    if (error.fields && Object.keys(error.fields).length)
+      return Object.entries(error.fields)
+        .map(([field, message]) => `${titleCase(field)}: ${message}`)
+        .join(" · ");
+    if (error.status === 409)
+      return "This relationship already exists or its source data changed. Refresh the relationship list and try again.";
+    if (error.status === 429)
+      return error.message || "You have reached the current generation limit.";
+    if (error.status === 503)
+      return "The relationship service is resting for a moment. Your details are safe—please retry.";
+    if (error.status === 422) return error.message;
     return error.message;
   }
-  return 'AstroMatch could not connect. Please try again.';
+  return "AstroMatch could not connect. Please try again.";
 }
 
-function StateMessage({title,text,action}:{title:string;text:string;action?:ReactNode}){
-  return <div className="relationship-state"><Sparkles/><h2>{title}</h2><p>{text}</p>{action}</div>;
+function StateMessage({
+  title,
+  text,
+  action,
+}: {
+  title: string;
+  text: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="relationship-state">
+      <Sparkles />
+      <h2>{title}</h2>
+      <p>{text}</p>
+      {action}
+    </div>
+  );
 }
 
-const blueprintFixture={
-  archetype:'The Tender Truth-Teller',
-  opening:'You connect most deeply where honesty and gentleness can coexist. Love becomes meaningful when it feels both emotionally real and spacious enough for two distinct people.',
-  sections:[
-    ['Core emotional needs','Consistency matters, but not at the cost of aliveness. You need a relationship where care is visible and curiosity remains active.'],
-    ['How you connect','You tend to build intimacy through specific attention: remembering details, noticing changes and making the other person feel genuinely observed.'],
-    ['Communication','Clarity is an act of affection for you. Ambiguity can feel more destabilising than a difficult truth delivered with care.'],
-    ['Conflict and repair','Your instinct may be to solve before both people feel understood. Repair becomes easier when emotion is named before logistics are negotiated.'],
-    ['Patterns worth noticing','Discernment protects you, but perfectionism can quietly turn connection into an evaluation. Notice when standards stop serving intimacy.'],
-    ['What supports you','A partner who respects your sensitivity, communicates directly and makes room for independent rhythms helps your relationships breathe.'],
+const blueprintFixture = {
+  archetype: "The Tender Truth-Teller",
+  opening:
+    "You connect most deeply where honesty and gentleness can coexist. Love becomes meaningful when it feels both emotionally real and spacious enough for two distinct people.",
+  sections: [
+    [
+      "Core emotional needs",
+      "Consistency matters, but not at the cost of aliveness. You need a relationship where care is visible and curiosity remains active.",
+    ],
+    [
+      "How you connect",
+      "You tend to build intimacy through specific attention: remembering details, noticing changes and making the other person feel genuinely observed.",
+    ],
+    [
+      "Communication",
+      "Clarity is an act of affection for you. Ambiguity can feel more destabilising than a difficult truth delivered with care.",
+    ],
+    [
+      "Conflict and repair",
+      "Your instinct may be to solve before both people feel understood. Repair becomes easier when emotion is named before logistics are negotiated.",
+    ],
+    [
+      "Patterns worth noticing",
+      "Discernment protects you, but perfectionism can quietly turn connection into an evaluation. Notice when standards stop serving intimacy.",
+    ],
+    [
+      "What supports you",
+      "A partner who respects your sensitivity, communicates directly and makes room for independent rhythms helps your relationships breathe.",
+    ],
   ],
 };
 
-export function BlueprintPage(){
-  const {data:state,loading,error,retry}=useLoad(async signal=>{await accountApi.get();return blueprintApi.get(signal)});
-  const [generating,setGenerating]=useState(false);
-  const [message,setMessage]=useState('');
-  useEffect(()=>track('blueprint_screen_viewed'),[]);
-  async function generate(regenerate=false){setGenerating(true);setMessage('');track(regenerate?'blueprint_regeneration_requested':'blueprint_generation_requested');try{await (regenerate?blueprintApi.regenerate():blueprintApi.generate());track('blueprint_generation_completed');retry()}catch(value){setMessage(safeMessage(value));track('blueprint_generation_failed')}finally{setGenerating(false)}}
-  if(loading)return <AppShell><GenerationProgress blueprint/></AppShell>;
-  if(error)return <AppShell><Page eyebrow="RELATIONSHIP BLUEPRINT" title="How you love is a story worth reading."/><StateMessage title="We couldn’t open your blueprint" text={error} action={<button className="button secondary" onClick={retry}>Retry</button>}/></AppShell>;
-  if(!state||state.status==='not_generated')return <AppShell><Page eyebrow="RELATIONSHIP BLUEPRINT" title="Your chart is ready. Now discover how you connect."/><StateMessage title="Begin your relationship blueprint" text="AstroMatch will read the relationship patterns in your backend-calculated natal chart." action={<button className="button" disabled={generating} onClick={()=>void generate()}>{generating?'Reading your chart patterns…':'Generate my blueprint'}</button>}/>{message&&<p role="alert" className="form-message">{message}</p>}</AppShell>;
-  if(state.status==='generating'||generating)return <AppShell><GenerationProgress blueprint/></AppShell>;
-  if(state.status==='failed')return <AppShell><Page eyebrow="RELATIONSHIP BLUEPRINT" title="We couldn’t finish this reading."/><StateMessage title="Your natal chart is safe" text={state.error??'Try generating the blueprint again when you’re ready.'} action={<button className="button secondary" onClick={()=>void generate()}>Try again</button>}/></AppShell>;
-  const blueprint=state.blueprint;
-  if(!blueprint&&env.VITE_ENABLE_DEV_FIXTURES)return <AppShell><article className="editorial-report blueprint-report"><header className="report-opening"><p className="eyebrow">DEVELOPMENT FIXTURE</p><h1>{blueprintFixture.archetype}</h1><p>{blueprintFixture.opening}</p></header></article></AppShell>;
-  if(!blueprint)return null;
-  const groups:[string,BlueprintInsight[]][]=[
-    ['Core emotional needs',blueprint.emotionalNeeds],
-    ['Affection style',blueprint.affectionStyle?[blueprint.affectionStyle]:[]],
-    ['Attraction style',blueprint.attractionStyle?[blueprint.attractionStyle]:[]],
-    ['Communication',blueprint.communicationStyle?[blueprint.communicationStyle]:[]],
-    ['Conflict and repair',blueprint.conflictStyle?[blueprint.conflictStyle]:[]],
-    ['Relationship strengths',blueprint.relationshipStrengths],
-    ['Growth edges',blueprint.growthEdges],
-    ['Dating patterns',blueprint.datingPatterns],
-    ['What supports you',blueprint.supportiveDynamics],
+export function BlueprintPage() {
+  const {
+    data: state,
+    loading,
+    error,
+    retry,
+  } = useLoad(async (signal) => {
+    await accountApi.get();
+    return blueprintApi.get(signal);
+  });
+  const [generating, setGenerating] = useState(false);
+  const [message, setMessage] = useState("");
+  useEffect(() => track("blueprint_screen_viewed"), []);
+  async function generate(regenerate = false) {
+    setGenerating(true);
+    setMessage("");
+    track(
+      regenerate
+        ? "blueprint_regeneration_requested"
+        : "blueprint_generation_requested",
+    );
+    try {
+      await (regenerate ? blueprintApi.regenerate() : blueprintApi.generate());
+      track("blueprint_generation_completed");
+      retry();
+    } catch (value) {
+      setMessage(safeMessage(value));
+      track("blueprint_generation_failed");
+    } finally {
+      setGenerating(false);
+    }
+  }
+  if (loading)
+    return (
+      <AppShell>
+        <GenerationProgress blueprint />
+      </AppShell>
+    );
+  if (error)
+    return (
+      <AppShell>
+        <Page
+          eyebrow="RELATIONSHIP BLUEPRINT"
+          title="How you love is a story worth reading."
+        />
+        <StateMessage
+          title="We couldn’t open your blueprint"
+          text={error}
+          action={
+            <button className="button secondary" onClick={retry}>
+              Retry
+            </button>
+          }
+        />
+      </AppShell>
+    );
+  if (!state || state.status === "not_generated")
+    return (
+      <AppShell>
+        <Page
+          eyebrow="RELATIONSHIP BLUEPRINT"
+          title="Your chart is ready. Now discover how you connect."
+        />
+        <StateMessage
+          title="Begin your relationship blueprint"
+          text="AstroMatch will read the relationship patterns in your backend-calculated natal chart."
+          action={
+            <button
+              className="button"
+              disabled={generating}
+              onClick={() => void generate()}
+            >
+              {generating
+                ? "Reading your chart patterns…"
+                : "Generate my blueprint"}
+            </button>
+          }
+        />
+        {message && (
+          <p role="alert" className="form-message">
+            {message}
+          </p>
+        )}
+      </AppShell>
+    );
+  if (state.status === "generating" || generating)
+    return (
+      <AppShell>
+        <GenerationProgress blueprint />
+      </AppShell>
+    );
+  if (state.status === "failed")
+    return (
+      <AppShell>
+        <Page
+          eyebrow="RELATIONSHIP BLUEPRINT"
+          title="We couldn’t finish this reading."
+        />
+        <StateMessage
+          title="Your natal chart is safe"
+          text={
+            state.error ??
+            "Try generating the blueprint again when you’re ready."
+          }
+          action={
+            <button
+              className="button secondary"
+              onClick={() => void generate()}
+            >
+              Try again
+            </button>
+          }
+        />
+      </AppShell>
+    );
+  const blueprint = state.blueprint;
+  if (!blueprint && env.VITE_ENABLE_DEV_FIXTURES)
+    return (
+      <AppShell>
+        <article className="editorial-report blueprint-report">
+          <header className="report-opening">
+            <p className="eyebrow">DEVELOPMENT FIXTURE</p>
+            <h1>{blueprintFixture.archetype}</h1>
+            <p>{blueprintFixture.opening}</p>
+          </header>
+        </article>
+      </AppShell>
+    );
+  if (!blueprint) return null;
+  const groups: [string, BlueprintInsight[]][] = [
+    ["Core emotional needs", blueprint.emotionalNeeds],
+    [
+      "Affection style",
+      blueprint.affectionStyle ? [blueprint.affectionStyle] : [],
+    ],
+    [
+      "Attraction style",
+      blueprint.attractionStyle ? [blueprint.attractionStyle] : [],
+    ],
+    [
+      "Communication",
+      blueprint.communicationStyle ? [blueprint.communicationStyle] : [],
+    ],
+    [
+      "Conflict and repair",
+      blueprint.conflictStyle ? [blueprint.conflictStyle] : [],
+    ],
+    ["Relationship strengths", blueprint.relationshipStrengths],
+    ["Growth edges", blueprint.growthEdges],
+    ["Dating patterns", blueprint.datingPatterns],
+    ["What supports you", blueprint.supportiveDynamics],
   ];
-  return <AppShell><article className="editorial-report blueprint-report"><header className="report-opening"><p className="eyebrow">YOUR RELATIONSHIP BLUEPRINT</p><Quality value={blueprint.dataQuality}/><h1>{blueprint.archetype.title}</h1><p>{blueprint.archetype.summary}</p></header>{groups.filter(([,items])=>items.length).map(([title,items],index)=><EditorialSection key={title} index={String(index+1).padStart(2,'0')} title={title}>{items.map(item=><article className="blueprint-insight" key={item.key}><h3>{item.title}</h3><p>{item.summary}</p><p>{item.detail}</p><small>{titleCase(item.confidence)} confidence</small></article>)}</EditorialSection>)}{!!blueprint.reflectionPrompts.length&&<section className="reflection-panel"><p className="eyebrow">REFLECT</p>{blueprint.reflectionPrompts.map(prompt=><h2 key={prompt}>{prompt}</h2>)}</section>}<div className="report-actions"><button className="button secondary" onClick={()=>void generate(true)} disabled={generating}><RefreshCw/>Regenerate blueprint</button></div><div className="notice"><ShieldCheck/>Interpretive reflection grounded in backend-provided chart factors.</div><Disclaimer/></article></AppShell>;
+  return (
+    <AppShell>
+      <article className="editorial-report blueprint-report">
+        <header className="report-opening">
+          <p className="eyebrow">YOUR RELATIONSHIP BLUEPRINT</p>
+          <Quality value={blueprint.dataQuality} />
+          <h1>{blueprint.archetype.title}</h1>
+          <p>{blueprint.archetype.summary}</p>
+        </header>
+        {groups
+          .filter(([, items]) => items.length)
+          .map(([title, items], index) => (
+            <EditorialSection
+              key={title}
+              index={String(index + 1).padStart(2, "0")}
+              title={title}
+            >
+              {items.map((item) => (
+                <article className="blueprint-insight" key={item.key}>
+                  <h3>{item.title}</h3>
+                  <p>{item.summary}</p>
+                  <p>{item.detail}</p>
+                  <small>{titleCase(item.confidence)} confidence</small>
+                </article>
+              ))}
+            </EditorialSection>
+          ))}
+        {!!blueprint.reflectionPrompts.length && (
+          <section className="reflection-panel">
+            <p className="eyebrow">REFLECT</p>
+            {blueprint.reflectionPrompts.map((prompt) => (
+              <h2 key={prompt}>{prompt}</h2>
+            ))}
+          </section>
+        )}
+        <div className="report-actions">
+          <button
+            className="button secondary"
+            onClick={() => void generate(true)}
+            disabled={generating}
+          >
+            <RefreshCw />
+            Regenerate blueprint
+          </button>
+        </div>
+        <div className="notice">
+          <ShieldCheck />
+          Interpretive reflection grounded in backend-provided chart factors.
+        </div>
+        <Disclaimer />
+      </article>
+    </AppShell>
+  );
 }
 
-export function PeoplePage(){
-  const {data:people,loading,error,retry}=useLoad(signal=>peopleApi.all(signal));
-  async function archive(person:PrivatePerson){
-    if(!confirm(`Archive ${person.displayName}'s private profile?`))return;
-    await peopleApi.archive(person.id);track('person_archived');retry();
+export function PeoplePage() {
+  const {
+    data: people,
+    loading,
+    error,
+    retry,
+  } = useLoad((signal) => peopleApi.all(signal));
+  async function archive(person: PrivatePerson) {
+    if (!confirm(`Archive ${person.displayName}'s private profile?`)) return;
+    await peopleApi.archive(person.id);
+    track("person_archived");
+    retry();
   }
-  return <AppShell><Page eyebrow="PRIVATE PEOPLE" title="The people in your inner world." action={<Link className="icon-button" to="/people/new" aria-label="Add a private person"><Plus/></Link>}/>
-    <div className="private-notice"><LockKeyhole/><div><strong>Private to you</strong><p>AstroMatch does not notify the people you add. Only enter information you are comfortable using for a private astrological interpretation.</p></div></div>
-    {loading?<RelationshipSkeleton/>:error?<StateMessage title="We couldn’t open your private people" text={error} action={<button className="button secondary" onClick={retry}>Retry</button>}/>:people?.length?<div className="people-ledger">{people.map(person=><article key={person.id}><Link to={`/people/${person.id}`}><span className="person-mark">{person.displayName.slice(0,1)}</span><div><small>{person.relationshipType}</small><h2>{person.displayName}</h2><p>{person.birthTimeStatus==='unknown'?'Time-independent reading available':`${person.birthTimeStatus} birth time`} · {person.chartStatus??'Chart status pending'}</p></div><Quality value={person.dataQuality??person.birthTimeStatus}/></Link><button onClick={()=>void archive(person)} aria-label={`Archive ${person.displayName}`}><Trash2/></button></article>)}</div>:<StateMessage title="Add someone privately to explore the astrology between you." text="A partner, spouse, crush, ex, friend or another meaningful connection." action={<ButtonLink to="/people/new">Add a private person</ButtonLink>}/>}
-  </AppShell>;
+  return (
+    <AppShell>
+      <Page
+        eyebrow="PRIVATE PEOPLE"
+        title="The people in your inner world."
+        action={
+          <Link
+            className="icon-button"
+            to="/people/new"
+            aria-label="Add a private person"
+          >
+            <Plus />
+          </Link>
+        }
+      />
+      <div className="private-notice">
+        <LockKeyhole />
+        <div>
+          <strong>Private to you</strong>
+          <p>
+            AstroMatch does not notify the people you add. Only enter
+            information you are comfortable using for a private astrological
+            interpretation.
+          </p>
+        </div>
+      </div>
+      {loading ? (
+        <RelationshipSkeleton />
+      ) : error ? (
+        <StateMessage
+          title="We couldn’t open your private people"
+          text={error}
+          action={
+            <button className="button secondary" onClick={retry}>
+              Retry
+            </button>
+          }
+        />
+      ) : people?.length ? (
+        <div className="people-ledger">
+          {people.map((person) => (
+            <article key={person.id}>
+              <Link to={`/people/${person.id}`}>
+                <span className="person-mark">
+                  {person.displayName.slice(0, 1)}
+                </span>
+                <div>
+                  <small>{person.relationshipType}</small>
+                  <h2>{person.displayName}</h2>
+                  <p>
+                    {person.birthTimeStatus === "unknown"
+                      ? "Time-independent reading available"
+                      : `${person.birthTimeStatus} birth time`}{" "}
+                    · {person.chartStatus ?? "Chart status pending"}
+                  </p>
+                </div>
+                <Quality value={person.dataQuality ?? person.birthTimeStatus} />
+              </Link>
+              <button
+                onClick={() => void archive(person)}
+                aria-label={`Archive ${person.displayName}`}
+              >
+                <Trash2 />
+              </button>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <StateMessage
+          title="Add someone privately to explore the astrology between you."
+          text="A partner, spouse, crush, ex, friend or another meaningful connection."
+          action={
+            <ButtonLink to="/people/new">Add a private person</ButtonLink>
+          }
+        />
+      )}
+    </AppShell>
+  );
 }
 
-export function PersonPage(){
-  const {personId}=useParams();
-  const navigate=useNavigate();
-  const {data:existing,loading,error}=useLoad(signal=>personId?peopleApi.get(personId,signal):Promise.resolve(null),[personId]);
-  const [saving,setSaving]=useState(false);
-  const [message,setMessage]=useState('');
-  const [timeQuality,setTimeQuality]=useState<PersonInput['birthTimeStatus']>('unknown');
-  useEffect(()=>{if(existing)setTimeQuality(existing.birthTimeStatus)},[existing]);
-  useEffect(()=>{if(!personId)track('person_creation_started')},[personId]);
+export function PersonPage() {
+  const { personId } = useParams();
+  const navigate = useNavigate();
+  const {
+    data: existing,
+    loading,
+    error,
+  } = useLoad(
+    (signal) =>
+      personId ? peopleApi.get(personId, signal) : Promise.resolve(null),
+    [personId],
+  );
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const [timeQuality, setTimeQuality] =
+    useState<PersonInput["birthTimeStatus"]>("unknown");
+  useEffect(() => {
+    if (existing) setTimeQuality(existing.birthTimeStatus);
+  }, [existing]);
+  useEffect(() => {
+    if (!personId) track("person_creation_started");
+  }, [personId]);
 
-  async function submit(event:FormEvent<HTMLFormElement>){
-    event.preventDefault();setSaving(true);setMessage('');
-    const form=new FormData(event.currentTarget);
-    const input:PersonInput={
-      displayName:String(form.get('displayName')).trim(),
-      pronouns:String(form.get('pronouns')).trim()||null,
-      relationshipType:String(form.get('relationshipType')) as PersonInput['relationshipType'],
-      birthDate:String(form.get('birthDate')),
-      birthTime:timeQuality==='unknown'?null:String(form.get('birthTime'))||null,
-      birthTimeStatus:timeQuality,
-      birthTimeAccuracyMinutes:timeQuality==='exact'?0:timeQuality==='approximate'?Number(form.get('birthTimeAccuracyMinutes'))||30:null,
-      birthPlaceLabel:String(form.get('birthPlaceLabel')).trim(),
-      latitude:Number(form.get('latitude')),
-      longitude:Number(form.get('longitude')),
-      timezone:String(form.get('timezone')).trim(),
-      astrologySystem:'western_tropical',
-      notes:String(form.get('notes')).trim()||null,
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    setMessage("");
+    const form = new FormData(event.currentTarget);
+    const input: PersonInput = {
+      displayName: String(form.get("displayName")).trim(),
+      pronouns: String(form.get("pronouns")).trim() || null,
+      relationshipType: String(
+        form.get("relationshipType"),
+      ) as PersonInput["relationshipType"],
+      birthDate: String(form.get("birthDate")),
+      birthTime:
+        timeQuality === "unknown"
+          ? null
+          : String(form.get("birthTime")) || null,
+      birthTimeStatus: timeQuality,
+      birthTimeAccuracyMinutes:
+        timeQuality === "exact"
+          ? 0
+          : timeQuality === "approximate"
+            ? Number(form.get("birthTimeAccuracyMinutes")) || 30
+            : null,
+      birthPlaceLabel: String(form.get("birthPlaceLabel")).trim(),
+      latitude: Number(form.get("latitude")),
+      longitude: Number(form.get("longitude")),
+      timezone: String(form.get("timezone")).trim(),
+      astrologySystem: "western_tropical",
+      notes: String(form.get("notes")).trim() || null,
+      dataConsentAcknowledged: form.get("dataConsentAcknowledged") === "on",
     };
-    try{
-      if(existing)await peopleApi.update(existing.id,input);else await peopleApi.create(input);
-      track(existing?'person_updated':'person_created',{relationship_type:input.relationshipType,birth_time_quality:input.birthTimeStatus});
-      navigate('/people');
-    }catch(value){setMessage(safeMessage(value))}finally{setSaving(false)}
+    try {
+      if (existing) await peopleApi.update(existing.id, input);
+      else await peopleApi.create(input);
+      track(existing ? "person_updated" : "person_created", {
+        relationship_type: input.relationshipType,
+        birth_time_quality: input.birthTimeStatus,
+      });
+      navigate("/people");
+    } catch (value) {
+      setMessage(safeMessage(value));
+    } finally {
+      setSaving(false);
+    }
   }
-  if(personId&&loading)return <AppShell><RelationshipSkeleton/></AppShell>;
-  if(error)return <AppShell><StateMessage title="This private profile is unavailable" text={error}/></AppShell>;
-  return <AppShell><Page eyebrow={existing?'EDIT PRIVATE PERSON':'ADD A PRIVATE PERSON'} title={existing?existing.displayName:'Who would you like to understand?'}/>
-    <form className="stack-form person-form" onSubmit={submit}>
-      <div className="private-notice"><LockKeyhole/><p>This profile is private to you. AstroMatch does not notify this person.</p></div>
-      <label>Private display name or alias<input name="displayName" defaultValue={existing?.displayName} maxLength={100} required/></label>
-      <div className="form-pair"><label>Relationship<select name="relationshipType" defaultValue={existing?.relationshipType??'dating'}>{['dating','partner','spouse','crush','ex','friend','custom'].map(value=><option key={value} value={value}>{titleCase(value)}</option>)}</select></label><label>Pronouns <span>optional</span><input name="pronouns" defaultValue={existing?.pronouns??''}/></label></div>
-      <label>Date of birth<input type="date" name="birthDate" defaultValue={existing?.birthDate} required/></label>
-      <fieldset><legend>How certain is the birth time?</legend><div className="choice-row">{(['exact','approximate','unknown'] as const).map(value=><label key={value}><input type="radio" name="birthTimeStatus" checked={timeQuality===value} onChange={()=>setTimeQuality(value)}/>{titleCase(value)}</label>)}</div></fieldset>
-      {timeQuality!=='unknown'&&<div className="form-pair"><label>Birth time<input type="time" name="birthTime" defaultValue={existing?.birthTime?.slice(0,5)??''} required/></label>{timeQuality==='approximate'&&<label>Accuracy window<select name="birthTimeAccuracyMinutes" defaultValue={existing?.birthTimeAccuracyMinutes??30}><option value="15">± 15 minutes</option><option value="30">± 30 minutes</option><option value="60">± 1 hour</option><option value="120">± 2 hours</option></select></label>}</div>}
-      {timeQuality==='unknown'&&<div className="notice"><Sparkles/>We can still compare planetary dynamics. Time-dependent houses and rising-sign interactions will be excluded.</div>}
-      <label>Birthplace<input name="birthPlaceLabel" defaultValue={existing?.birthPlaceLabel} placeholder="City, region, country" required/></label>
-      <div className="form-triad"><label>Latitude<input type="number" step="any" min="-90" max="90" name="latitude" defaultValue={existing?.latitude} required/></label><label>Longitude<input type="number" step="any" min="-180" max="180" name="longitude" defaultValue={existing?.longitude} required/></label><label>Timezone<input name="timezone" list="relationship-timezones" defaultValue={existing?.timezone??Intl.DateTimeFormat().resolvedOptions().timeZone} required/></label></div>
-      <datalist id="relationship-timezones">{Intl.supportedValuesOf('timeZone').map(value=><option key={value} value={value}/>)}</datalist>
-      <label>Private note <span>optional</span><textarea name="notes" defaultValue={existing?.notes??''} maxLength={2000}/></label>
-      {message&&<p role="alert" className="form-message">{message}</p>}<button className="button" disabled={saving}>{saving?'Saving privately…':'Save private person'}</button>
-    </form>
-  </AppShell>;
+  if (personId && loading)
+    return (
+      <AppShell>
+        <RelationshipSkeleton />
+      </AppShell>
+    );
+  if (error)
+    return (
+      <AppShell>
+        <StateMessage
+          title="This private profile is unavailable"
+          text={error}
+        />
+      </AppShell>
+    );
+  return (
+    <AppShell>
+      <Page
+        eyebrow={existing ? "EDIT PRIVATE PERSON" : "ADD A PRIVATE PERSON"}
+        title={
+          existing ? existing.displayName : "Who would you like to understand?"
+        }
+      />
+      <form className="stack-form person-form" onSubmit={submit}>
+        <div className="private-notice">
+          <LockKeyhole />
+          <p>
+            This profile is private to you. AstroMatch does not notify this
+            person.
+          </p>
+        </div>
+        <label>
+          Private display name or alias
+          <input
+            name="displayName"
+            defaultValue={existing?.displayName}
+            maxLength={100}
+            required
+          />
+        </label>
+        <div className="form-pair">
+          <label>
+            Relationship
+            <select
+              name="relationshipType"
+              defaultValue={existing?.relationshipType ?? "dating"}
+            >
+              {[
+                "dating",
+                "partner",
+                "spouse",
+                "crush",
+                "ex",
+                "friend",
+                "custom",
+              ].map((value) => (
+                <option key={value} value={value}>
+                  {titleCase(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Pronouns <span>optional</span>
+            <input name="pronouns" defaultValue={existing?.pronouns ?? ""} />
+          </label>
+        </div>
+        <label>
+          Date of birth
+          <input
+            type="date"
+            name="birthDate"
+            defaultValue={existing?.birthDate}
+            required
+          />
+        </label>
+        <fieldset>
+          <legend>How certain is the birth time?</legend>
+          <div className="choice-row">
+            {(["exact", "approximate", "unknown"] as const).map((value) => (
+              <label key={value}>
+                <input
+                  type="radio"
+                  name="birthTimeStatus"
+                  checked={timeQuality === value}
+                  onChange={() => setTimeQuality(value)}
+                />
+                {titleCase(value)}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+        {timeQuality !== "unknown" && (
+          <div className="form-pair">
+            <label>
+              Birth time
+              <input
+                type="time"
+                name="birthTime"
+                defaultValue={existing?.birthTime?.slice(0, 5) ?? ""}
+                required
+              />
+            </label>
+            {timeQuality === "approximate" && (
+              <label>
+                Accuracy window
+                <select
+                  name="birthTimeAccuracyMinutes"
+                  defaultValue={existing?.birthTimeAccuracyMinutes ?? 30}
+                >
+                  <option value="15">± 15 minutes</option>
+                  <option value="30">± 30 minutes</option>
+                  <option value="60">± 1 hour</option>
+                  <option value="120">± 2 hours</option>
+                </select>
+              </label>
+            )}
+          </div>
+        )}
+        {timeQuality === "unknown" && (
+          <div className="notice">
+            <Sparkles />
+            We can still compare planetary dynamics. Time-dependent houses and
+            rising-sign interactions will be excluded.
+          </div>
+        )}
+        <label>
+          Birthplace
+          <input
+            name="birthPlaceLabel"
+            defaultValue={existing?.birthPlaceLabel}
+            placeholder="City, region, country"
+            required
+          />
+        </label>
+        <div className="form-triad">
+          <label>
+            Latitude
+            <input
+              type="number"
+              step="any"
+              min="-90"
+              max="90"
+              name="latitude"
+              defaultValue={existing?.latitude}
+              required
+            />
+          </label>
+          <label>
+            Longitude
+            <input
+              type="number"
+              step="any"
+              min="-180"
+              max="180"
+              name="longitude"
+              defaultValue={existing?.longitude}
+              required
+            />
+          </label>
+          <label>
+            Timezone
+            <input
+              name="timezone"
+              list="relationship-timezones"
+              defaultValue={
+                existing?.timezone ??
+                Intl.DateTimeFormat().resolvedOptions().timeZone
+              }
+              required
+            />
+          </label>
+        </div>
+        <datalist id="relationship-timezones">
+          {Intl.supportedValuesOf("timeZone").map((value) => (
+            <option key={value} value={value} />
+          ))}
+        </datalist>
+        <label>
+          Private note <span>optional</span>
+          <textarea
+            name="notes"
+            defaultValue={existing?.notes ?? ""}
+            maxLength={2000}
+          />
+        </label>
+        <label className="consent-check">
+          <input
+            type="checkbox"
+            name="dataConsentAcknowledged"
+            defaultChecked={existing?.dataConsentAcknowledged}
+            required
+          />
+          <span>
+            I confirm I have permission to use this person’s birth information
+            for this private analysis.
+          </span>
+        </label>
+        {message && (
+          <p role="alert" className="form-message">
+            {message}
+          </p>
+        )}
+        <button className="button" disabled={saving}>
+          {saving ? "Saving privately…" : "Save private person"}
+        </button>
+      </form>
+    </AppShell>
+  );
 }
 
-export function RelationshipsPage(){
-  const {data:relationships,loading,error,retry}=useLoad(signal=>relationshipsApi.all(signal));
-  async function archive(item:Relationship){if(!confirm('Archive this relationship analysis?'))return;await relationshipsApi.archive(item.id);track('relationship_archived');retry()}
-  return <AppShell><Page eyebrow="RELATIONSHIPS" title="Your relationship space." action={<Link className="icon-button" to="/relationships/new" aria-label="Analyse a relationship"><Plus/></Link>}/>
-    <p className="page-intro">Private dossiers for the connections you want to understand—not a public matches feed.</p>
-    {loading?<RelationshipSkeleton/>:error?<StateMessage title="Your relationships couldn’t be loaded" text={error} action={<button className="button secondary" onClick={retry}>Retry</button>}/>:relationships?.length?<div className="relationship-ledger">{relationships.map(item=><article key={item.id}><Link to={`/relationships/${item.id}`}><div className="relationship-monogram"><span>You</span><span>{item.person?.displayName.slice(0,1)??'·'}</span></div><div><small>{titleCase(item.focus??'general')} · {titleCase(item.reportStatus)}</small><h2>{item.title??item.person?.displayName??'Private relationship'}</h2><p>{item.qualitativeLabel??item.headline??statusCopy(item.status)}</p></div><Quality value={item.dataQuality??item.compatibilityStatus}/>{typeof item.score==='number'&&<em>{Math.round(item.score)}</em>}</Link><button onClick={()=>void archive(item)} aria-label="Archive relationship"><Trash2/></button></article>)}</div>:<StateMessage title="Your relationship space is empty." text="Add someone privately, then create your first relationship analysis." action={<ButtonLink to="/relationships/new">Analyse a relationship</ButtonLink>}/>}
-  </AppShell>;
+export function RelationshipsPage() {
+  const {
+    data: relationships,
+    loading,
+    error,
+    retry,
+  } = useLoad((signal) => relationshipsApi.all(signal));
+  async function archive(item: Relationship) {
+    if (!confirm("Archive this relationship analysis?")) return;
+    await relationshipsApi.archive(item.id);
+    track("relationship_archived");
+    retry();
+  }
+  return (
+    <AppShell>
+      <Page
+        eyebrow="RELATIONSHIPS"
+        title="Your relationship space."
+        action={
+          <Link
+            className="icon-button"
+            to="/relationships/new"
+            aria-label="Analyse a relationship"
+          >
+            <Plus />
+          </Link>
+        }
+      />
+      <p className="page-intro">
+        Private dossiers for the connections you want to understand—not a public
+        matches feed.
+      </p>
+      {loading ? (
+        <RelationshipSkeleton />
+      ) : error ? (
+        <StateMessage
+          title="Your relationships couldn’t be loaded"
+          text={error}
+          action={
+            <button className="button secondary" onClick={retry}>
+              Retry
+            </button>
+          }
+        />
+      ) : relationships?.length ? (
+        <div className="relationship-ledger">
+          {relationships.map((item) => (
+            <article key={item.id}>
+              <Link to={`/relationships/${item.id}`}>
+                <div className="relationship-monogram">
+                  <span>You</span>
+                  <span>{item.person?.displayName.slice(0, 1) ?? "·"}</span>
+                </div>
+                <div>
+                  <small>
+                    {titleCase(item.focus ?? "general")} ·{" "}
+                    {titleCase(item.reportStatus)}
+                  </small>
+                  <h2>
+                    {item.title ??
+                      item.person?.displayName ??
+                      "Private relationship"}
+                  </h2>
+                  <p>
+                    {item.qualitativeLabel ??
+                      item.headline ??
+                      statusCopy(item.status)}
+                  </p>
+                </div>
+                <Quality value={item.dataQuality ?? item.compatibilityStatus} />
+                {typeof item.score === "number" && (
+                  <em>{Math.round(item.score)}</em>
+                )}
+              </Link>
+              <button
+                onClick={() => void archive(item)}
+                aria-label="Archive relationship"
+              >
+                <Trash2 />
+              </button>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <StateMessage
+          title="Your relationship space is empty."
+          text="Add someone privately, then create your first relationship analysis."
+          action={
+            <ButtonLink to="/relationships/new">
+              Analyse a relationship
+            </ButtonLink>
+          }
+        />
+      )}
+    </AppShell>
+  );
 }
 
-export function NewRelationshipPage(){
-  const navigate=useNavigate();
-  const {data:options,loading,error}=useLoad(async signal=>({people:await peopleApi.all(signal),profiles:await birthProfilesApi.list()}));
-  const people=options?.people;
-  const profiles=options?.profiles;
-  const [phase,setPhase]=useState<'form'|'confirm'|'generating'>('form');
-  const [birthProfileId,setBirthProfileId]=useState('');
-  const [personId,setPersonId]=useState('');
-  const [focus,setFocus]=useState<MatchFocus>('general');
-  const [message,setMessage]=useState('');
-  useEffect(()=>track('relationship_creation_started'),[]);
-  const person=people?.find(item=>item.id===personId);
-  useEffect(()=>{if(!birthProfileId&&profiles?.length)setBirthProfileId(profiles.find(item=>item.is_primary)?.id??profiles[0].id)},[birthProfileId,profiles]);
-  async function create(){
-    if(!personId||!birthProfileId)return;setPhase('generating');setMessage('');
-    track('relationship_created',{relationship_type:person?.relationshipType??'custom',analysis_focus:focus});
-    track('compatibility_calculation_requested',{focus});
-    try{
-      const relationship=await relationshipsApi.create({birth_profile_id:birthProfileId,person_id:personId,relationship_type:person?.relationshipType??'dating',title:null});
-      await relationshipsApi.calculate(relationship.id,focus);
-      track('compatibility_calculation_completed',{focus,data_quality:person?.dataQuality??'unknown'});
-      track('compatibility_report_generation_requested');
+export function NewRelationshipPage() {
+  const navigate = useNavigate();
+  const {
+    data: options,
+    loading,
+    error,
+  } = useLoad(async (signal) => ({
+    people: await peopleApi.all(signal),
+    profiles: await birthProfilesApi.list(),
+  }));
+  const people = options?.people;
+  const profiles = options?.profiles;
+  const [phase, setPhase] = useState<"form" | "confirm" | "generating">("form");
+  const [birthProfileId, setBirthProfileId] = useState("");
+  const [personId, setPersonId] = useState("");
+  const [focus, setFocus] = useState<MatchFocus>("general");
+  const [message, setMessage] = useState("");
+  useEffect(() => track("relationship_creation_started"), []);
+  const person = people?.find((item) => item.id === personId);
+  useEffect(() => {
+    if (!birthProfileId && profiles?.length)
+      setBirthProfileId(
+        profiles.find((item) => item.is_primary)?.id ?? profiles[0].id,
+      );
+  }, [birthProfileId, profiles]);
+  async function create() {
+    if (!personId || !birthProfileId) return;
+    setPhase("generating");
+    setMessage("");
+    track("relationship_created", {
+      relationship_type: person?.relationshipType ?? "custom",
+      analysis_focus: focus,
+    });
+    track("compatibility_calculation_requested", { focus });
+    try {
+      const relationship = await relationshipsApi.create({
+        birth_profile_id: birthProfileId,
+        person_id: personId,
+        relationship_type: person?.relationshipType ?? "dating",
+        title: null,
+      });
+      await relationshipsApi.calculate(relationship.id, focus);
+      track("compatibility_calculation_completed", {
+        focus,
+        data_quality: person?.dataQuality ?? "unknown",
+      });
+      track("compatibility_report_generation_requested");
       await relationshipsApi.generateReport(relationship.id);
-      track('compatibility_report_generated');
+      track("compatibility_report_generated");
       navigate(`/relationships/${relationship.id}/report`);
-    }catch(value){setPhase('confirm');setMessage(safeMessage(value));track('compatibility_calculation_failed',{error_category:value instanceof ApiError?value.code:'network'})}
+    } catch (value) {
+      setPhase("confirm");
+      setMessage(safeMessage(value));
+      track("compatibility_calculation_failed", {
+        error_category: value instanceof ApiError ? value.code : "network",
+      });
+    }
   }
-  if(loading)return <AppShell><RelationshipSkeleton/></AppShell>;
-  if(error)return <AppShell><StateMessage title="We couldn’t prepare a new analysis" text={error}/></AppShell>;
-  if(!people?.length)return <AppShell><Page eyebrow="NEW RELATIONSHIP" title="Begin with someone private."/><StateMessage title="Add a person first" text="AstroMatch needs their private birth profile before it can compare your charts." action={<ButtonLink to="/people/new">Add a private person</ButtonLink>}/></AppShell>;
-  if(phase==='generating')return <AppShell><GenerationProgress/></AppShell>;
-  return <AppShell><Page eyebrow="NEW RELATIONSHIP" title={phase==='confirm'?'Review before we begin':'What would you like to understand?'}/>
-    {phase==='form'?<form className="relationship-builder" onSubmit={event=>{event.preventDefault();setPhase('confirm')}}>
-      <label>Choose your birth profile<select value={birthProfileId} onChange={event=>setBirthProfileId(event.target.value)} required>{profiles?.map(profile=><option key={profile.id} value={profile.id}>{profile.display_name}</option>)}</select></label>
-      <label>Choose a private person<select value={personId} onChange={event=>setPersonId(event.target.value)} required><option value="">Select someone</option>{people.map(item=><option key={item.id} value={item.id}>{item.displayName} · {item.relationshipType}</option>)}</select></label>
-      <fieldset><legend>Choose a focus</legend>{focusOptions.map(([value,label,description])=><label className={focus===value?'selected':''} key={value}><input type="radio" name="focus" value={value} checked={focus===value} onChange={()=>setFocus(value)}/><span><strong>{label}</strong><small>{description}</small></span></label>)}</fieldset>
-      <button className="button" disabled={!personId||!birthProfileId}>Review analysis <ArrowRight/></button>
-    </form>:<section className="generation-confirm"><p className="eyebrow">PRIVATE ANALYSIS</p><h2>You + {person?.displayName}</h2><dl><div><dt>Relationship</dt><dd>{titleCase(person?.relationshipType??'custom')}</dd></div><div><dt>Focus</dt><dd>{focusOptions.find(item=>item[0]===focus)?.[1]}</dd></div><div><dt>Birth-time quality</dt><dd>{titleCase(person?.birthTimeStatus??'unknown')}</dd></div></dl>{person?.birthTimeStatus==='unknown'&&<div className="notice"><Sparkles/>House and rising-sign interactions will not be included. Planetary compatibility can still be analysed.</div>}<p>Your saved details remain private. Generation may use your current AI allowance.</p>{message&&<p className="form-message" role="alert">{message}</p>}<div className="report-actions"><button className="button" onClick={()=>void create()}>Calculate compatibility</button><button className="button secondary" onClick={()=>setPhase('form')}>Go back</button></div></section>}
-  </AppShell>;
+  if (loading)
+    return (
+      <AppShell>
+        <RelationshipSkeleton />
+      </AppShell>
+    );
+  if (error)
+    return (
+      <AppShell>
+        <StateMessage title="We couldn’t prepare a new analysis" text={error} />
+      </AppShell>
+    );
+  if (!people?.length)
+    return (
+      <AppShell>
+        <Page eyebrow="NEW RELATIONSHIP" title="Begin with someone private." />
+        <StateMessage
+          title="Add a person first"
+          text="AstroMatch needs their private birth profile before it can compare your charts."
+          action={
+            <ButtonLink to="/people/new">Add a private person</ButtonLink>
+          }
+        />
+      </AppShell>
+    );
+  if (phase === "generating")
+    return (
+      <AppShell>
+        <GenerationProgress />
+      </AppShell>
+    );
+  return (
+    <AppShell>
+      <Page
+        eyebrow="NEW RELATIONSHIP"
+        title={
+          phase === "confirm"
+            ? "Review before we begin"
+            : "What would you like to understand?"
+        }
+      />
+      {phase === "form" ? (
+        <form
+          className="relationship-builder"
+          onSubmit={(event) => {
+            event.preventDefault();
+            setPhase("confirm");
+          }}
+        >
+          <label>
+            Choose your birth profile
+            <select
+              value={birthProfileId}
+              onChange={(event) => setBirthProfileId(event.target.value)}
+              required
+            >
+              {profiles?.map((profile) => (
+                <option key={profile.id} value={profile.id}>
+                  {profile.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Choose a private person
+            <select
+              value={personId}
+              onChange={(event) => setPersonId(event.target.value)}
+              required
+            >
+              <option value="">Select someone</option>
+              {people.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.displayName} · {item.relationshipType}
+                </option>
+              ))}
+            </select>
+          </label>
+          <fieldset>
+            <legend>Choose a focus</legend>
+            {focusOptions.map(([value, label, description]) => (
+              <label className={focus === value ? "selected" : ""} key={value}>
+                <input
+                  type="radio"
+                  name="focus"
+                  value={value}
+                  checked={focus === value}
+                  onChange={() => setFocus(value)}
+                />
+                <span>
+                  <strong>{label}</strong>
+                  <small>{description}</small>
+                </span>
+              </label>
+            ))}
+          </fieldset>
+          <button className="button" disabled={!personId || !birthProfileId}>
+            Review analysis <ArrowRight />
+          </button>
+        </form>
+      ) : (
+        <section className="generation-confirm">
+          <p className="eyebrow">PRIVATE ANALYSIS</p>
+          <h2>You + {person?.displayName}</h2>
+          <dl>
+            <div>
+              <dt>Relationship</dt>
+              <dd>{titleCase(person?.relationshipType ?? "custom")}</dd>
+            </div>
+            <div>
+              <dt>Focus</dt>
+              <dd>{focusOptions.find((item) => item[0] === focus)?.[1]}</dd>
+            </div>
+            <div>
+              <dt>Birth-time quality</dt>
+              <dd>{titleCase(person?.birthTimeStatus ?? "unknown")}</dd>
+            </div>
+          </dl>
+          {person?.birthTimeStatus === "unknown" && (
+            <div className="notice">
+              <Sparkles />
+              House and rising-sign interactions will not be included. Planetary
+              compatibility can still be analysed.
+            </div>
+          )}
+          <p>
+            Your saved details remain private. Generation may use your current
+            AI allowance.
+          </p>
+          {message && (
+            <p className="form-message" role="alert">
+              {message}
+            </p>
+          )}
+          <div className="report-actions">
+            <button className="button" onClick={() => void create()}>
+              Calculate compatibility
+            </button>
+            <button
+              className="button secondary"
+              onClick={() => setPhase("form")}
+            >
+              Go back
+            </button>
+          </div>
+        </section>
+      )}
+    </AppShell>
+  );
 }
 
-export function RelationshipPage(){
-  const {relationshipId=''}=useParams();
-  const {data:item,loading,error,retry}=useLoad(signal=>relationshipsApi.get(relationshipId,signal),[relationshipId]);
-  const compatibility=useLoad(signal=>relationshipsApi.compatibility(relationshipId,signal),[relationshipId]);
-  if(loading)return <AppShell><RelationshipSkeleton/></AppShell>;
-  if(error||!item)return <AppShell><StateMessage title="This relationship is unavailable" text={error||'It may have been archived.'}/></AppShell>;
-  const action=item.reportStatus==='report_ready'
-    ?<ButtonLink to={`/relationships/${item.id}/report`}>Open relationship report</ButtonLink>
-    :item.compatibilityStatus==='compatibility_ready'
-      ?<button className="button" onClick={async()=>{await relationshipsApi.generateReport(item.id);retry()}}>Generate narrative report</button>
-      :<button className="button" onClick={async()=>{await relationshipsApi.calculate(item.id,item.focus??'general');retry()}}>Calculate compatibility</button>;
-  return <AppShell><Page eyebrow="RELATIONSHIP" title={item.title??item.person?.displayName??'Private relationship'}/><section className="relationship-overview"><Quality value={item.dataQuality??compatibility.data?.dataQuality??item.compatibilityStatus}/><h2>{item.headline??item.qualitativeLabel??compatibility.data?.qualitativeLabel??statusCopy(item.status)}</h2><p>{titleCase(item.compatibilityStatus)} · {titleCase(item.reportStatus)}</p>{action}</section>{item.compatibilityStatus==='compatibility_ready'&&compatibility.data&&<section className="compatibility-preview"><div className="chart-section-heading"><div><p className="eyebrow">DETERMINISTIC COMPATIBILITY</p><h2>{compatibility.data.qualitativeLabel??'Relationship dynamics'}</h2></div>{typeof compatibility.data.overall==='number'&&<span>{Math.round(compatibility.data.overall)} · reflective score</span>}</div><div className="compatibility-categories">{compatibility.data.categories.map(category=><article key={category.key}><small>{category.qualitativeLabel??category.confidence}</small><h3>{category.label}</h3>{typeof category.score==='number'&&<strong>{Math.round(category.score)}</strong>}<p>{category.interpretation}</p></article>)}</div>{!!compatibility.data.exclusions.length&&<div className="notice"><Sparkles/>{compatibility.data.exclusions.join(' ')}</div>}</section>}</AppShell>;
+export function RelationshipPage() {
+  const { relationshipId = "" } = useParams();
+  const {
+    data: item,
+    loading,
+    error,
+    retry,
+  } = useLoad(
+    (signal) => relationshipsApi.get(relationshipId, signal),
+    [relationshipId],
+  );
+  const compatibility = useLoad(
+    (signal) => relationshipsApi.compatibility(relationshipId, signal),
+    [relationshipId],
+  );
+  if (loading)
+    return (
+      <AppShell>
+        <RelationshipSkeleton />
+      </AppShell>
+    );
+  if (error || !item)
+    return (
+      <AppShell>
+        <StateMessage
+          title="This relationship is unavailable"
+          text={error || "It may have been archived."}
+        />
+      </AppShell>
+    );
+  const action =
+    item.reportStatus === "report_ready" ? (
+      <ButtonLink to={`/relationships/${item.id}/report`}>
+        Open relationship report
+      </ButtonLink>
+    ) : item.compatibilityStatus === "compatibility_ready" ? (
+      <button
+        className="button"
+        onClick={async () => {
+          await relationshipsApi.generateReport(item.id);
+          retry();
+        }}
+      >
+        Generate narrative report
+      </button>
+    ) : item.compatibilityStatus === "compatibility_calculating" ? (
+      <button className="button" disabled>
+        Calculating compatibility…
+      </button>
+    ) : (
+      <button
+        className="button"
+        onClick={async () => {
+          await relationshipsApi.calculate(item.id, item.focus ?? "general");
+          retry();
+        }}
+      >
+        {item.compatibilityStatus === "compatibility_failed"
+          ? "Retry compatibility"
+          : "Calculate compatibility"}
+      </button>
+    );
+  return (
+    <AppShell>
+      <Page
+        eyebrow="RELATIONSHIP"
+        title={item.title ?? item.person?.displayName ?? "Private relationship"}
+      />
+      <section className="relationship-overview">
+        <Quality
+          value={
+            item.dataQuality ??
+            compatibility.data?.dataQuality ??
+            item.compatibilityStatus
+          }
+        />
+        <h2>
+          {item.headline ??
+            item.qualitativeLabel ??
+            compatibility.data?.qualitativeLabel ??
+            statusCopy(item.status)}
+        </h2>
+        <p>
+          {titleCase(item.compatibilityStatus)} · {titleCase(item.reportStatus)}
+        </p>
+        {action}
+      </section>
+      {item.compatibilityStatus === "compatibility_ready" &&
+        compatibility.data && (
+          <section className="compatibility-preview">
+            <div className="chart-section-heading">
+              <div>
+                <p className="eyebrow">DETERMINISTIC COMPATIBILITY</p>
+                <h2>
+                  {compatibility.data.qualitativeLabel ??
+                    "Relationship dynamics"}
+                </h2>
+              </div>
+              {typeof compatibility.data.overall === "number" && (
+                <span>
+                  {Math.round(compatibility.data.overall)} · reflective score
+                </span>
+              )}
+            </div>
+            <div className="compatibility-categories">
+              {compatibility.data.categories.map((category) => (
+                <article key={category.key}>
+                  <small>
+                    {category.qualitativeLabel ?? category.confidence}
+                  </small>
+                  <h3>{category.label}</h3>
+                  {typeof category.score === "number" && (
+                    <strong>{Math.round(category.score)}</strong>
+                  )}
+                  <p>{category.interpretation}</p>
+                </article>
+              ))}
+            </div>
+            {!!compatibility.data.exclusions.length && (
+              <div className="notice">
+                <Sparkles />
+                {compatibility.data.exclusions.join(" ")}
+              </div>
+            )}
+          </section>
+        )}
+    </AppShell>
+  );
 }
 
-export function RelationshipReportPage(){
-  const {relationshipId=''}=useParams();
-  const {data:report,loading,error,retry}=useLoad(signal=>relationshipsApi.report(relationshipId,signal),[relationshipId]);
-  useEffect(()=>{if(report)track('compatibility_report_viewed')},[report]);
-  if(loading)return <AppShell><GenerationProgress reading/></AppShell>;
-  if(error||!report)return <AppShell><Page eyebrow="RELATIONSHIP REPORT" title="The reading isn’t available yet."/><StateMessage title="We couldn’t finish this reading" text={error||'Your chart and relationship details are safe.'} action={<button className="button secondary" onClick={retry}>Try again</button>}/></AppShell>;
-  return <AppShell><article className="editorial-report compatibility-report">
-    <header className="report-opening"><p className="eyebrow">PRIVATE RELATIONSHIP DOSSIER</p><Quality value={report.dataQuality??'available'}/><h1>{report.headline??report.qualitativeLabel??'A relationship with its own language'}</h1><p>{report.summary??'Your backend-generated relationship interpretation is ready.'}</p>{typeof report.overallScore==='number'&&<div className="context-score"><strong>{Math.round(report.overallScore)}</strong><span>Supporting context—not a verdict</span></div>}</header>
-    {report.strongestConnection&&<EditorialSection index="01" title={report.strongestConnection.title??'Strongest connection'}><p>{report.strongestConnection.body}</p></EditorialSection>}
-    {report.primaryFriction&&<EditorialSection index="02" title={report.primaryFriction.title??'Primary friction'}><p>{report.primaryFriction.body}</p></EditorialSection>}
-    {report.categories?.map((category,index)=><CategorySection key={category.key} category={category} index={String(index+3).padStart(2,'0')}/>)}
-    {!!report.practicalGuidance?.length&&<EditorialSection index="G" title="Practical guidance"><ul>{report.practicalGuidance.map((item,index)=><li key={index}>{item.title&&<strong>{item.title}: </strong>}{item.body}</li>)}</ul></EditorialSection>}
-    {!!report.reflectionPrompts?.length&&<section className="reflection-panel"><p className="eyebrow">REFLECTION PROMPTS</p>{report.reflectionPrompts.map(item=><h2 key={item}>{item}</h2>)}</section>}
-    {!!report.factors?.length&&<Evidence factors={report.factors}/>}
-    {!!report.limitations?.length&&<section className="report-limitations"><h2>What this reading cannot know</h2>{report.limitations.map(item=><p key={item}>{item}</p>)}</section>}
-    {report.canRegenerate&&<section className="regeneration-notice"><RefreshCw/><div><h2>A refreshed report is available</h2><p>{report.regenerationReason}</p><button className="button secondary" onClick={async()=>{track('compatibility_report_regeneration_requested');await relationshipsApi.regenerateReport(relationshipId);retry()}}>Regenerate report</button></div></section>}
-    <div className="private-notice"><LockKeyhole/><p>This report is private by default. Sharing must be deliberate, and birth details are excluded from share cards.</p></div><Disclaimer/>
-  </article></AppShell>;
+export function RelationshipReportPage() {
+  const { relationshipId = "" } = useParams();
+  const {
+    data: report,
+    loading,
+    error,
+    retry,
+  } = useLoad(
+    (signal) => relationshipsApi.report(relationshipId, signal),
+    [relationshipId],
+  );
+  const [actionMessage, setActionMessage] = useState("");
+  useEffect(() => {
+    if (report) track("compatibility_report_viewed");
+  }, [report]);
+  if (loading)
+    return (
+      <AppShell>
+        <GenerationProgress reading />
+      </AppShell>
+    );
+  if (error || !report)
+    return (
+      <AppShell>
+        <Page
+          eyebrow="RELATIONSHIP REPORT"
+          title="The reading isn’t available yet."
+        />
+        <StateMessage
+          title="We couldn’t finish this reading"
+          text={error || "Your chart and relationship details are safe."}
+          action={
+            <button className="button secondary" onClick={retry}>
+              Try again
+            </button>
+          }
+        />
+      </AppShell>
+    );
+  return (
+    <AppShell>
+      <article className="editorial-report compatibility-report">
+        <header className="report-opening">
+          <p className="eyebrow">PRIVATE RELATIONSHIP DOSSIER</p>
+          <Quality value={report.dataQuality ?? "available"} />
+          <h1>
+            {report.headline ??
+              report.qualitativeLabel ??
+              "A relationship with its own language"}
+          </h1>
+          <p>
+            {report.summary ??
+              "Your backend-generated relationship interpretation is ready."}
+          </p>
+          {typeof report.overallScore === "number" && (
+            <div className="context-score">
+              <strong>{Math.round(report.overallScore)}</strong>
+              <span>Supporting context—not a verdict</span>
+            </div>
+          )}
+        </header>
+        {report.strongestConnection && (
+          <EditorialSection
+            index="01"
+            title={report.strongestConnection.title ?? "Strongest connection"}
+          >
+            <p>{report.strongestConnection.body}</p>
+          </EditorialSection>
+        )}
+        {report.primaryFriction && (
+          <EditorialSection
+            index="02"
+            title={report.primaryFriction.title ?? "Primary friction"}
+          >
+            <p>{report.primaryFriction.body}</p>
+          </EditorialSection>
+        )}
+        {report.categories?.map((category, index) => (
+          <CategorySection
+            key={category.key}
+            category={category}
+            index={String(index + 3).padStart(2, "0")}
+          />
+        ))}
+        {!!report.practicalGuidance?.length && (
+          <EditorialSection index="G" title="Practical guidance">
+            <ul>
+              {report.practicalGuidance.map((item, index) => (
+                <li key={index}>
+                  {item.title && <strong>{item.title}: </strong>}
+                  {item.body}
+                </li>
+              ))}
+            </ul>
+          </EditorialSection>
+        )}
+        {!!report.reflectionPrompts?.length && (
+          <section className="reflection-panel">
+            <p className="eyebrow">REFLECTION PROMPTS</p>
+            {report.reflectionPrompts.map((item) => (
+              <h2 key={item}>{item}</h2>
+            ))}
+          </section>
+        )}
+        {!!report.factors?.length && <Evidence factors={report.factors} />}
+        {!!report.limitations?.length && (
+          <section className="report-limitations">
+            <h2>What this reading cannot know</h2>
+            {report.limitations.map((item) => (
+              <p key={item}>{item}</p>
+            ))}
+          </section>
+        )}
+        {report.canRegenerate && (
+          <section className="regeneration-notice">
+            <RefreshCw />
+            <div>
+              <h2>A refreshed report is available</h2>
+              <p>{report.regenerationReason}</p>
+              <button
+                className="button secondary"
+                onClick={async () => {
+                  track("compatibility_report_regeneration_requested");
+                  await relationshipsApi.regenerateReport(relationshipId);
+                  retry();
+                }}
+              >
+                Regenerate report
+              </button>
+            </div>
+          </section>
+        )}
+        <div className="report-actions">
+          <ButtonLink to={`/ask?relationshipId=${relationshipId}`}>
+            Ask about this relationship
+          </ButtonLink>
+          <button
+            className="button secondary"
+            disabled={!report.id}
+            onClick={async () => {
+              if (!report.id) return;
+              try {
+                await libraryApi.save({
+                  item_type: "relationship_report",
+                  relationship_id: relationshipId,
+                  report_id: report.id,
+                });
+                setActionMessage("Report saved to your private library.");
+                track("compatibility_report_saved");
+              } catch (value) {
+                setActionMessage(safeMessage(value));
+              }
+            }}
+          >
+            Save report
+          </button>
+          <button
+            className="button secondary"
+            onClick={async () => {
+              try {
+                const card = await libraryApi.createShare(relationshipId);
+                const label =
+                  card.payload.strongest_category?.replaceAll("_", " ") ??
+                  "relationship compatibility";
+                const text = `AstroMatch reflection: strongest theme — ${label}. Birth details and identities are excluded.`;
+                const share = (
+                  navigator as unknown as {
+                    share?: (data: ShareData) => Promise<void>;
+                  }
+                ).share;
+                if (share)
+                  await share({
+                    title: "AstroMatch relationship reflection",
+                    text,
+                  });
+                else await navigator.clipboard.writeText(text);
+                setActionMessage(
+                  share ? "Share sheet opened." : "Private summary copied.",
+                );
+                track("share_report_cta_clicked");
+              } catch (value) {
+                setActionMessage(safeMessage(value));
+              }
+            }}
+          >
+            Create safe share card
+          </button>
+        </div>
+        {actionMessage && (
+          <p className="form-message" role="status">
+            {actionMessage}
+          </p>
+        )}
+        <div className="private-notice">
+          <LockKeyhole />
+          <p>
+            This report is private by default. Sharing must be deliberate, and
+            birth details are excluded from share cards.
+          </p>
+        </div>
+        <Disclaimer />
+      </article>
+    </AppShell>
+  );
 }
 
-function CategorySection({category,index}:{category:CompatibilityCategory;index:string}){
-  return <EditorialSection index={index} title={category.label}><div className="category-heading">{category.dataQuality&&<Quality value={category.dataQuality}/>} {typeof category.score==='number'&&<span>{Math.round(category.score)} · with context</span>}</div>{category.headline&&<h3>{category.headline}</h3>}<p>{category.interpretation}</p>{(category.supportingFactors?.length||category.challengingFactors?.length)?<details onToggle={event=>{if(event.currentTarget.open)track('compatibility_category_expanded',{category_key:category.key})}}><summary>View astrological evidence <ChevronDown/></summary><FactorList title="Supporting" factors={category.supportingFactors}/><FactorList title="Challenging" factors={category.challengingFactors}/></details>:null}</EditorialSection>;
+function CategorySection({
+  category,
+  index,
+}: {
+  category: CompatibilityCategory;
+  index: string;
+}) {
+  return (
+    <EditorialSection index={index} title={category.label}>
+      <div className="category-heading">
+        {category.dataQuality && <Quality value={category.dataQuality} />}{" "}
+        {typeof category.score === "number" && (
+          <span>{Math.round(category.score)} · with context</span>
+        )}
+      </div>
+      {category.headline && <h3>{category.headline}</h3>}
+      <p>{category.interpretation}</p>
+      {category.supportingFactors?.length ||
+      category.challengingFactors?.length ? (
+        <details
+          onToggle={(event) => {
+            if (event.currentTarget.open)
+              track("compatibility_category_expanded", {
+                category_key: category.key,
+              });
+          }}
+        >
+          <summary>
+            View astrological evidence <ChevronDown />
+          </summary>
+          <FactorList title="Supporting" factors={category.supportingFactors} />
+          <FactorList
+            title="Challenging"
+            factors={category.challengingFactors}
+          />
+        </details>
+      ) : null}
+    </EditorialSection>
+  );
 }
 
-function FactorList({title,factors}:{title:string;factors?:CompatibilityFactor[]}){if(!factors?.length)return null;return <div className="factor-list"><h4>{title}</h4>{factors.map((factor,index)=><p key={index}><strong>{factor.title??factor.label??[factor.planetA,factor.aspect,factor.planetB].filter(Boolean).join(' ')}</strong>{factor.interpretation??factor.description}{typeof factor.orb==='number'&&<small>{factor.orb.toFixed(2)}° orb</small>}</p>)}</div>}
-function Evidence({factors}:{factors:CompatibilityFactor[]}){return <section className="evidence-section"><details><summary>Astrological basis <ChevronDown/></summary><FactorList title="Backend-provided factors" factors={factors}/></details></section>}
-function EditorialSection({index,title,children}:{index:string;title:string;children:ReactNode}){return <section className="editorial-section"><span>{index}</span><div><h2>{title}</h2>{children}</div></section>}
-function Quality({value}:{value:string}){return <span className="data-quality"><i/>{titleCase(value)}</span>}
-function RelationshipSkeleton(){return <div className="relationship-skeleton" aria-label="Loading" role="status"><i/><i/><i/></div>}
-function GenerationProgress({reading=false,blueprint=false}:{reading?:boolean;blueprint?:boolean}){return <section className="generation-progress" aria-live="polite"><span/><p className="eyebrow">{blueprint?'PREPARING YOUR RELATIONSHIP BLUEPRINT':reading?'OPENING YOUR REPORT':'CALCULATING PRIVATELY'}</p><h1>{blueprint?'Reading your chart patterns…':reading?'Returning to the space between you…':'Reading the relationship between two charts…'}</h1>{!blueprint&&<ol><li>Preparing both charts</li><li>Comparing major placements</li><li>Identifying relationship themes</li><li>Writing your report</li></ol>}</section>}
-function titleCase(value:string){return value.replaceAll('_',' ').replace(/\b\w/g,letter=>letter.toUpperCase())}
-function statusCopy(status:Relationship['status']){return {draft:'Ready to calculate when you are.',ready:'Ready for compatibility calculation.',analysed:'Your relationship analysis is ready.',archived:'This relationship has been archived.'}[status]}
+function FactorList({
+  title,
+  factors,
+}: {
+  title: string;
+  factors?: CompatibilityFactor[];
+}) {
+  if (!factors?.length) return null;
+  return (
+    <div className="factor-list">
+      <h4>{title}</h4>
+      {factors.map((factor, index) => (
+        <p key={index}>
+          <strong>
+            {factor.title ??
+              factor.label ??
+              [factor.planetA, factor.aspect, factor.planetB]
+                .filter(Boolean)
+                .join(" ")}
+          </strong>
+          {factor.interpretation ?? factor.description}
+          {typeof factor.orb === "number" && (
+            <small>{factor.orb.toFixed(2)}° orb</small>
+          )}
+        </p>
+      ))}
+    </div>
+  );
+}
+function Evidence({ factors }: { factors: CompatibilityFactor[] }) {
+  return (
+    <section className="evidence-section">
+      <details>
+        <summary>
+          Astrological basis <ChevronDown />
+        </summary>
+        <FactorList title="Backend-provided factors" factors={factors} />
+      </details>
+    </section>
+  );
+}
+function EditorialSection({
+  index,
+  title,
+  children,
+}: {
+  index: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="editorial-section">
+      <span>{index}</span>
+      <div>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    </section>
+  );
+}
+function Quality({ value }: { value: string }) {
+  return (
+    <span className="data-quality">
+      <i />
+      {titleCase(value)}
+    </span>
+  );
+}
+function RelationshipSkeleton() {
+  return (
+    <div className="relationship-skeleton" aria-label="Loading" role="status">
+      <i />
+      <i />
+      <i />
+    </div>
+  );
+}
+function GenerationProgress({
+  reading = false,
+  blueprint = false,
+}: {
+  reading?: boolean;
+  blueprint?: boolean;
+}) {
+  return (
+    <section className="generation-progress" aria-live="polite">
+      <span />
+      <p className="eyebrow">
+        {blueprint
+          ? "PREPARING YOUR RELATIONSHIP BLUEPRINT"
+          : reading
+            ? "OPENING YOUR REPORT"
+            : "CALCULATING PRIVATELY"}
+      </p>
+      <h1>
+        {blueprint
+          ? "Reading your chart patterns…"
+          : reading
+            ? "Returning to the space between you…"
+            : "Reading the relationship between two charts…"}
+      </h1>
+      {!blueprint && (
+        <ol>
+          <li>Preparing both charts</li>
+          <li>Comparing major placements</li>
+          <li>Identifying relationship themes</li>
+          <li>Writing your report</li>
+        </ol>
+      )}
+    </section>
+  );
+}
+function titleCase(value: string) {
+  return value
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+function statusCopy(status: Relationship["status"]) {
+  return {
+    draft: "Ready to calculate when you are.",
+    ready: "Ready for compatibility calculation.",
+    analysed: "Your relationship analysis is ready.",
+    archived: "This relationship has been archived.",
+  }[status];
+}

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1,11 +1,143 @@
 /* eslint-disable react-refresh/only-export-components */
-import type { ReactNode } from 'react'; import { Link, NavLink, useLocation } from 'react-router-dom'; import { Home, Heart, MessageCircle, BookOpen, UserRound, ArrowUpRight, Sparkles } from 'lucide-react'; import { track } from './lib/analytics';
-export const routes={home:'/home',blueprint:'/blueprint',ask:'/ask',relationships:'/relationships',people:'/people',saved:'/saved',profile:'/profile',settings:'/settings'} as const;
-export function Brand(){return <Link to="/" className="brand" aria-label="AstroMatch home"><span>✦</span> AstroMatch</Link>}
-export function PublicHeader(){return <header className="public-header"><Brand/><nav><Link to="/about">About</Link><Link to="/privacy">Privacy</Link><Link className="text-link" to="/login">Sign in <ArrowUpRight size={15}/></Link></nav></header>}
-const nav=[['Today',routes.home,Home],['Blueprint',routes.blueprint,BookOpen],['Relationships',routes.relationships,Heart],['Ask',routes.ask,MessageCircle],['Me',routes.profile,UserRound]] as const;
-export function AppShell({children}: {children:ReactNode}){return <div className="app-shell"><aside><Brand/><nav>{nav.map(([label,to,Icon])=><NavLink key={to} to={to}><Icon/><span>{label}</span></NavLink>)}</nav><div className="rail-note"><Sparkles/><p>Your profiles stay private.</p></div></aside><main className="app-main">{children}</main><nav className="bottom-nav" aria-label="Primary">{nav.map(([label,to,Icon])=><NavLink key={to} to={to}><Icon/><span>{label}</span></NavLink>)}</nav></div>}
-export function Page({eyebrow,title,children,action}:{eyebrow?:string;title:string;children?:ReactNode;action?:ReactNode}){return <><header className="page-head">{eyebrow&&<p className="eyebrow">{eyebrow}</p>}<div><h1>{title}</h1>{action}</div></header>{children}</>}
-export function ButtonLink({to,children,secondary=false}:{to:string;children:ReactNode;secondary?:boolean}){return <Link onClick={()=>track('primary_cta_clicked',{cta_name:String(children),page_name:location.hash})} className={secondary?'button secondary':'button'} to={to}>{children}</Link>}
-export function PageTracker(){const location=useLocation(); track('page_view',{page_path:location.pathname}); return null}
-export const Disclaimer=()=> <p className="disclaimer">AstroMatch offers astrological interpretations for reflection and entertainment. It does not replace professional medical, legal, financial or mental-health advice.</p>;
+import type { ReactNode } from "react";
+import { Link, NavLink, useLocation } from "react-router-dom";
+import {
+  Home,
+  Heart,
+  MessageCircle,
+  BookOpen,
+  UserRound,
+  ArrowUpRight,
+  Sparkles,
+  Bookmark,
+} from "lucide-react";
+import { track } from "./lib/analytics";
+export const routes = {
+  home: "/home",
+  blueprint: "/blueprint",
+  ask: "/ask",
+  relationships: "/relationships",
+  people: "/people",
+  saved: "/saved",
+  profile: "/profile",
+  settings: "/settings",
+} as const;
+export function Brand() {
+  return (
+    <Link to="/" className="brand" aria-label="AstroMatch home">
+      <span>✦</span> AstroMatch
+    </Link>
+  );
+}
+export function PublicHeader() {
+  return (
+    <header className="public-header">
+      <Brand />
+      <nav>
+        <Link to="/about">About</Link>
+        <Link to="/privacy">Privacy</Link>
+        <Link className="text-link" to="/login">
+          Sign in <ArrowUpRight size={15} />
+        </Link>
+      </nav>
+    </header>
+  );
+}
+const nav = [
+  ["Today", routes.home, Home],
+  ["Blueprint", routes.blueprint, BookOpen],
+  ["Relationships", routes.relationships, Heart],
+  ["Ask", routes.ask, MessageCircle],
+  ["Saved", routes.saved, Bookmark],
+  ["Me", routes.profile, UserRound],
+] as const;
+export function AppShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="app-shell">
+      <aside>
+        <Brand />
+        <nav>
+          {nav.map(([label, to, Icon]) => (
+            <NavLink key={to} to={to}>
+              <Icon />
+              <span>{label}</span>
+            </NavLink>
+          ))}
+        </nav>
+        <div className="rail-note">
+          <Sparkles />
+          <p>Your profiles stay private.</p>
+        </div>
+      </aside>
+      <main className="app-main">{children}</main>
+      <nav className="bottom-nav" aria-label="Primary">
+        {nav.map(([label, to, Icon]) => (
+          <NavLink key={to} to={to}>
+            <Icon />
+            <span>{label}</span>
+          </NavLink>
+        ))}
+      </nav>
+    </div>
+  );
+}
+export function Page({
+  eyebrow,
+  title,
+  children,
+  action,
+}: {
+  eyebrow?: string;
+  title: string;
+  children?: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <>
+      <header className="page-head">
+        {eyebrow && <p className="eyebrow">{eyebrow}</p>}
+        <div>
+          <h1>{title}</h1>
+          {action}
+        </div>
+      </header>
+      {children}
+    </>
+  );
+}
+export function ButtonLink({
+  to,
+  children,
+  secondary = false,
+}: {
+  to: string;
+  children: ReactNode;
+  secondary?: boolean;
+}) {
+  return (
+    <Link
+      onClick={() =>
+        track("primary_cta_clicked", {
+          cta_name: String(children),
+          page_name: location.hash,
+        })
+      }
+      className={secondary ? "button secondary" : "button"}
+      to={to}
+    >
+      {children}
+    </Link>
+  );
+}
+export function PageTracker() {
+  const location = useLocation();
+  track("page_view", { page_path: location.pathname });
+  return null;
+}
+export const Disclaimer = () => (
+  <p className="disclaimer">
+    AstroMatch offers astrological interpretations for reflection and
+    entertainment. It does not replace professional medical, legal, financial or
+    mental-health advice.
+  </p>
+);

--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -1,10 +1,13 @@
-import { api } from './api';
+import { api } from "./api";
 
-export type NextOnboardingStep = 'complete_profile' | 'create_birth_profile' | null;
+export type NextOnboardingStep =
+  | "complete_profile"
+  | "create_birth_profile"
+  | null;
 
 export interface AccountState {
   id: string;
-  profile_status: 'incomplete' | 'profile_complete' | 'complete';
+  profile_status: "incomplete" | "profile_complete" | "complete";
   onboarding_completed: boolean;
   next_step: NextOnboardingStep;
   profile?: {
@@ -38,48 +41,82 @@ export interface ProfileInput {
   bio?: string | null;
 }
 
-const timezoneAliases:Record<string,string>={
-  'Asia/Calcutta':'Asia/Kolkata',
-  'US/Eastern':'America/New_York',
-  'US/Central':'America/Chicago',
-  'US/Mountain':'America/Denver',
-  'US/Pacific':'America/Los_Angeles',
+const timezoneAliases: Record<string, string> = {
+  "Asia/Calcutta": "Asia/Kolkata",
+  "US/Eastern": "America/New_York",
+  "US/Central": "America/Chicago",
+  "US/Mountain": "America/Denver",
+  "US/Pacific": "America/Los_Angeles",
 };
 
-const timezoneCountries:Record<string,string>={
-  'Asia/Kolkata':'IN','Asia/Colombo':'LK','Asia/Kathmandu':'NP','Asia/Dhaka':'BD','Asia/Karachi':'PK',
-  'Asia/Dubai':'AE','Asia/Singapore':'SG','Asia/Tokyo':'JP','Asia/Seoul':'KR','Asia/Shanghai':'CN','Asia/Hong_Kong':'HK',
-  'Australia/Sydney':'AU','Pacific/Auckland':'NZ','Europe/London':'GB','Europe/Dublin':'IE','Europe/Paris':'FR','Europe/Berlin':'DE',
-  'America/New_York':'US','America/Chicago':'US','America/Denver':'US','America/Los_Angeles':'US',
-  'America/Toronto':'CA','America/Vancouver':'CA',
+const timezoneCountries: Record<string, string> = {
+  "Asia/Kolkata": "IN",
+  "Asia/Colombo": "LK",
+  "Asia/Kathmandu": "NP",
+  "Asia/Dhaka": "BD",
+  "Asia/Karachi": "PK",
+  "Asia/Dubai": "AE",
+  "Asia/Singapore": "SG",
+  "Asia/Tokyo": "JP",
+  "Asia/Seoul": "KR",
+  "Asia/Shanghai": "CN",
+  "Asia/Hong_Kong": "HK",
+  "Australia/Sydney": "AU",
+  "Pacific/Auckland": "NZ",
+  "Europe/London": "GB",
+  "Europe/Dublin": "IE",
+  "Europe/Paris": "FR",
+  "Europe/Berlin": "DE",
+  "America/New_York": "US",
+  "America/Chicago": "US",
+  "America/Denver": "US",
+  "America/Los_Angeles": "US",
+  "America/Toronto": "CA",
+  "America/Vancouver": "CA",
 };
 
-export function normalizeTimezone(value:string){
-  return timezoneAliases[value]??value;
+export function normalizeTimezone(value: string) {
+  return timezoneAliases[value] ?? value;
 }
 
-export function inferCountryCode(timezone:string,locale:string){
-  const timezoneCountry=timezoneCountries[normalizeTimezone(timezone)];
-  if(timezoneCountry)return timezoneCountry;
-  try{return new Intl.Locale(locale).maximize().region??'US'}catch{return 'US'}
+export function inferCountryCode(timezone: string, locale: string) {
+  const timezoneCountry = timezoneCountries[normalizeTimezone(timezone)];
+  if (timezoneCountry) return timezoneCountry;
+  try {
+    return new Intl.Locale(locale).maximize().region ?? "US";
+  } catch {
+    return "US";
+  }
 }
 
 export const accountApi = {
-  get: () => api<AccountState>('/api/v1/me'),
-  updateProfile: (profile: ProfileInput) => api<AccountState>('/api/v1/me/profile', {
-    method: 'PATCH',
-    body: JSON.stringify(profile),
-  }),
-  completeProfile: (profile: ProfileInput) => api<AccountState>('/api/v1/me/profile/complete', {
-    method: 'POST',
-    body: JSON.stringify(profile),
-  }),
+  get: () => api<AccountState>("/api/v1/me"),
+  updateProfile: (profile: ProfileInput) =>
+    api<AccountState>("/api/v1/me/profile", {
+      method: "PATCH",
+      body: JSON.stringify(profile),
+    }),
+  completeProfile: (profile: ProfileInput) =>
+    api<AccountState>("/api/v1/me/profile/complete", {
+      method: "POST",
+      body: JSON.stringify(profile),
+    }),
+  exportData: () => api<Record<string, unknown>>("/api/v1/me/export"),
+  deleteAccount: () =>
+    api<{ status: string; retention_days: number; scheduled_purge_at: string }>(
+      "/api/v1/me",
+      { method: "DELETE" },
+    ),
 };
 
 export function routeForAccount(account: AccountState) {
-  if (account.onboarding_completed && account.profile_status === 'complete') return '/home';
-  if (account.next_step === 'create_birth_profile' || account.profile_status === 'profile_complete') {
-    return '/onboarding/birth-profile';
+  if (account.onboarding_completed && account.profile_status === "complete")
+    return "/home";
+  if (
+    account.next_step === "create_birth_profile" ||
+    account.profile_status === "profile_complete"
+  ) {
+    return "/onboarding/birth-profile";
   }
-  return '/onboarding/profile';
+  return "/onboarding/profile";
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,13 +1,93 @@
-import { env } from './env';
-export type EventName='sign_up_started'|'sign_up_completed'|'login_completed'|'logout_completed'|'onboarding_started'|'onboarding_step_viewed'|'birth_time_status_selected'|'onboarding_completed'|'person_creation_started'|'person_created'|'person_updated'|'person_deleted'|'person_archived'|'match_creation_started'|'match_focus_selected'|'match_generation_requested'|'match_generation_completed'|'match_generation_failed'|'match_report_viewed'|'match_report_saved'|'share_card_generated'|'share_started'|'ask_screen_viewed'|'suggested_question_clicked'|'astrology_question_submitted'|'astrology_answer_completed'|'astrology_answer_failed'|'astrology_answer_feedback'|'primary_cta_clicked'|'pricing_interest_clicked'|'legal_page_viewed'|'page_view'|'blueprint_screen_viewed'|'blueprint_generation_requested'|'blueprint_generation_completed'|'blueprint_generation_failed'|'blueprint_section_expanded'|'blueprint_regeneration_requested'|'relationship_creation_started'|'relationship_created'|'relationship_opened'|'relationship_archived'|'compatibility_calculation_requested'|'compatibility_calculation_completed'|'compatibility_calculation_failed'|'compatibility_report_generation_requested'|'compatibility_report_generated'|'compatibility_report_viewed'|'compatibility_category_expanded'|'compatibility_report_regeneration_requested'|'add_person_cta_clicked'|'analyse_relationship_cta_clicked'|'ask_about_relationship_cta_clicked'|'share_report_cta_clicked';
-type Params=Record<string,string|number|boolean|undefined>; declare global{interface Window{gtag?:(command:string,name:string,params?:Params)=>void}}
-const consent=()=>localStorage.getItem('am:analytics-consent')==='granted';
-const forbiddenKey=/(^|_)(name|alias|email|uid|uuid|id|birth|place|location|latitude|longitude|note|content|question|answer|factor|report)(_|$)/i;
-const uuid=/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi;
-export function sanitizeAnalyticsParams(params:Params){
-  return Object.fromEntries(Object.entries(params)
-    .filter(([key,value])=>!forbiddenKey.test(key)&&['string','number','boolean'].includes(typeof value))
-    .map(([key,value])=>[key,typeof value==='string'?value.replace(uuid,':private'):value])) as Params;
+import { env } from "./env";
+export type EventName =
+  | "compatibility_report_saved"
+  | "sign_up_started"
+  | "sign_up_completed"
+  | "login_completed"
+  | "logout_completed"
+  | "onboarding_started"
+  | "onboarding_step_viewed"
+  | "birth_time_status_selected"
+  | "onboarding_completed"
+  | "person_creation_started"
+  | "person_created"
+  | "person_updated"
+  | "person_deleted"
+  | "person_archived"
+  | "match_creation_started"
+  | "match_focus_selected"
+  | "match_generation_requested"
+  | "match_generation_completed"
+  | "match_generation_failed"
+  | "match_report_viewed"
+  | "match_report_saved"
+  | "share_card_generated"
+  | "share_started"
+  | "ask_screen_viewed"
+  | "suggested_question_clicked"
+  | "astrology_question_submitted"
+  | "astrology_answer_completed"
+  | "astrology_answer_failed"
+  | "astrology_answer_feedback"
+  | "primary_cta_clicked"
+  | "pricing_interest_clicked"
+  | "legal_page_viewed"
+  | "page_view"
+  | "blueprint_screen_viewed"
+  | "blueprint_generation_requested"
+  | "blueprint_generation_completed"
+  | "blueprint_generation_failed"
+  | "blueprint_section_expanded"
+  | "blueprint_regeneration_requested"
+  | "relationship_creation_started"
+  | "relationship_created"
+  | "relationship_opened"
+  | "relationship_archived"
+  | "compatibility_calculation_requested"
+  | "compatibility_calculation_completed"
+  | "compatibility_calculation_failed"
+  | "compatibility_report_generation_requested"
+  | "compatibility_report_generated"
+  | "compatibility_report_viewed"
+  | "compatibility_category_expanded"
+  | "compatibility_report_regeneration_requested"
+  | "add_person_cta_clicked"
+  | "analyse_relationship_cta_clicked"
+  | "ask_about_relationship_cta_clicked"
+  | "share_report_cta_clicked";
+type Params = Record<string, string | number | boolean | undefined>;
+declare global {
+  interface Window {
+    gtag?: (command: string, name: string, params?: Params) => void;
+  }
 }
-export function track(name:EventName,params:Params={}){if(env.VITE_ENABLE_ANALYTICS!=='true'||!consent())return;window.gtag?.('event',name,sanitizeAnalyticsParams(params))}
-export function setAnalyticsConsent(value:boolean){localStorage.setItem('am:analytics-consent',value?'granted':'denied');window.gtag?.('consent','update',{'analytics_storage':value?'granted':'denied'} as Params)}
+const consent = () =>
+  localStorage.getItem("am:analytics-consent") === "granted";
+const forbiddenKey =
+  /(^|_)(name|alias|email|uid|uuid|id|birth|place|location|latitude|longitude|note|content|question|answer|factor|report)(_|$)/i;
+const uuid =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi;
+export function sanitizeAnalyticsParams(params: Params) {
+  return Object.fromEntries(
+    Object.entries(params)
+      .filter(
+        ([key, value]) =>
+          !forbiddenKey.test(key) &&
+          ["string", "number", "boolean"].includes(typeof value),
+      )
+      .map(([key, value]) => [
+        key,
+        typeof value === "string" ? value.replace(uuid, ":private") : value,
+      ]),
+  ) as Params;
+}
+export function track(name: EventName, params: Params = {}) {
+  if (env.VITE_ENABLE_ANALYTICS !== "true" || !consent()) return;
+  window.gtag?.("event", name, sanitizeAnalyticsParams(params));
+}
+export function setAnalyticsConsent(value: boolean) {
+  localStorage.setItem("am:analytics-consent", value ? "granted" : "denied");
+  window.gtag?.("consent", "update", {
+    analytics_storage: value ? "granted" : "denied",
+  } as Params);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,65 +1,123 @@
-import { auth } from './firebase';
-import { env } from './env';
+import { auth } from "./firebase";
+import { env } from "./env";
 
-export type ApiErrorCode='VALIDATION_ERROR'|'UNAUTHENTICATED'|'FORBIDDEN'|'NOT_FOUND'|'CONFLICT'|'RATE_LIMITED'|'SERVER_ERROR'|'NETWORK_ERROR';
-export class ApiError extends Error { constructor(public code:ApiErrorCode,message:string,public status:number,public fields?:Record<string,string>,public requestId?:string){super(message)} }
-const codes:Record<number,ApiErrorCode>={400:'VALIDATION_ERROR',401:'UNAUTHENTICATED',403:'FORBIDDEN',404:'NOT_FOUND',409:'CONFLICT',422:'VALIDATION_ERROR',429:'RATE_LIMITED'};
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "UNAUTHENTICATED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "RATE_LIMITED"
+  | "SERVER_ERROR"
+  | "NETWORK_ERROR"
+  | "ACCOUNT_DELETED"
+  | "PERSON_DATA_CONSENT_REQUIRED"
+  | "AI_USAGE_LIMIT_REACHED"
+  | "AI_PROVIDER_ERROR"
+  | (string & {});
+export class ApiError extends Error {
+  constructor(
+    public code: ApiErrorCode,
+    message: string,
+    public status: number,
+    public fields?: Record<string, string>,
+    public requestId?: string,
+  ) {
+    super(message);
+  }
+}
+const codes: Record<number, ApiErrorCode> = {
+  400: "VALIDATION_ERROR",
+  401: "UNAUTHENTICATED",
+  403: "FORBIDDEN",
+  404: "NOT_FOUND",
+  409: "CONFLICT",
+  422: "VALIDATION_ERROR",
+  429: "RATE_LIMITED",
+};
 
-export function requestHeaders(options:RequestInit,token:string|undefined,requestId:string){
-  const headers=new Headers(options.headers);
-  if(options.body!=null&&!headers.has('Content-Type'))headers.set('Content-Type','application/json');
-  headers.set('X-Request-ID',requestId);
-  if(token)headers.set('Authorization',`Bearer ${token}`);
+export function requestHeaders(
+  options: RequestInit,
+  token: string | undefined,
+  requestId: string,
+) {
+  const headers = new Headers(options.headers);
+  if (options.body != null && !headers.has("Content-Type"))
+    headers.set("Content-Type", "application/json");
+  headers.set("X-Request-ID", requestId);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
   return headers;
 }
 
-export async function api<T>(path:string,options:RequestInit={}){
-  const requestId=crypto.randomUUID();
-  const isGet=(options.method??'GET').toUpperCase()==='GET';
-  const maxAttempts=isGet?3:1;
-  let forceTokenRefresh=false;
-  for(let attempt=0;attempt<maxAttempts;attempt++){
-    const token=await auth?.currentUser?.getIdToken(forceTokenRefresh);
-    try{
-      const response=await fetch(`${env.VITE_API_BASE_URL}${path}`,{
+export async function api<T>(path: string, options: RequestInit = {}) {
+  const requestId = crypto.randomUUID();
+  const isGet = (options.method ?? "GET").toUpperCase() === "GET";
+  const maxAttempts = isGet ? 3 : 1;
+  let forceTokenRefresh = false;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const token = await auth?.currentUser?.getIdToken(forceTokenRefresh);
+    try {
+      const response = await fetch(`${env.VITE_API_BASE_URL}${path}`, {
         ...options,
-        headers:requestHeaders(options,token,requestId),
+        headers: requestHeaders(options, token, requestId),
       });
-      if(response.status===401&&!forceTokenRefresh&&auth?.currentUser){
-        forceTokenRefresh=true;
+      if (response.status === 401 && !forceTokenRefresh && auth?.currentUser) {
+        forceTokenRefresh = true;
         attempt--;
         continue;
       }
-      const body=await response.json().catch(()=>({}));
-      if(!response.ok){
-        const error=body?.error;
-        const apiError=new ApiError(
-          codes[response.status]??(response.status>=500?'SERVER_ERROR':'VALIDATION_ERROR'),
-          error?.message??friendly(response.status),
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const error = body?.error;
+        const apiError = new ApiError(
+          error?.code ??
+            codes[response.status] ??
+            (response.status >= 500 ? "SERVER_ERROR" : "VALIDATION_ERROR"),
+          error?.message ?? friendly(response.status),
           response.status,
           error?.fields,
-          body?.meta?.requestId??requestId,
+          body?.meta?.requestId ?? requestId,
         );
-        if(isGet&&(response.status===500||response.status===503)&&attempt<maxAttempts-1){
+        if (
+          isGet &&
+          (response.status === 500 || response.status === 503) &&
+          attempt < maxAttempts - 1
+        ) {
           await retryDelay(attempt);
           continue;
         }
         throw apiError;
       }
-      return (body?.data??body) as T;
-    }catch(error){
-      if(error instanceof ApiError)throw error;
-      if((error as Error).name==='AbortError')throw error;
-      if(isGet&&attempt<maxAttempts-1){
+      return (body?.data ?? body) as T;
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+      if ((error as Error).name === "AbortError") throw error;
+      if (isGet && attempt < maxAttempts - 1) {
         await retryDelay(attempt);
         continue;
       }
-      throw new ApiError('NETWORK_ERROR','AstroMatch could not connect. Please try again.',0);
+      throw new ApiError(
+        "NETWORK_ERROR",
+        "AstroMatch could not connect. Please try again.",
+        0,
+      );
     }
   }
-  throw new ApiError('NETWORK_ERROR','AstroMatch could not connect. Please try again.',0);
+  throw new ApiError(
+    "NETWORK_ERROR",
+    "AstroMatch could not connect. Please try again.",
+    0,
+  );
 }
 
-const retryDelay=(attempt:number)=>new Promise(resolve=>setTimeout(resolve,250*(2**attempt)));
+const retryDelay = (attempt: number) =>
+  new Promise((resolve) => setTimeout(resolve, 250 * 2 ** attempt));
 
-function friendly(status:number){if(status===401)return 'Your session has expired. Please sign in again.';if(status===429)return 'You’ve reached the current limit. Please try again later.';if(status>=500)return 'AstroMatch is having a quiet moment. Please try again.';return 'We could not complete that request.'}
+function friendly(status: number) {
+  if (status === 401) return "Your session has expired. Please sign in again.";
+  if (status === 429)
+    return "You’ve reached the current limit. Please try again later.";
+  if (status >= 500)
+    return "AstroMatch is having a quiet moment. Please try again.";
+  return "We could not complete that request.";
+}

--- a/src/lib/conversations.ts
+++ b/src/lib/conversations.ts
@@ -1,0 +1,110 @@
+import { api } from "./api";
+
+export type ConversationContext = "general" | "personal" | "relationship";
+export interface Conversation {
+  id: string;
+  title: string;
+  contextType: ConversationContext;
+  relationshipId?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+export interface AssistantPayload {
+  answer: string;
+  reflectionPrompts: string[];
+  limitations: string[];
+}
+export interface ConversationMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  assistantPayload?: AssistantPayload;
+  createdAt?: string;
+}
+
+const obj = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : {};
+const str = (value: unknown) => (typeof value === "string" ? value : undefined);
+const strings = (value: unknown) =>
+  Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+function conversation(value: unknown): Conversation {
+  const x = obj(value);
+  return {
+    id: str(x.id) ?? "",
+    title: str(x.title) ?? "Private conversation",
+    contextType: (str(x.contextType) ??
+      str(x.context_type) ??
+      "personal") as ConversationContext,
+    relationshipId: str(x.relationshipId) ?? str(x.relationship_id) ?? null,
+    createdAt: str(x.createdAt) ?? str(x.created_at),
+    updatedAt: str(x.updatedAt) ?? str(x.updated_at),
+  };
+}
+function message(value: unknown): ConversationMessage {
+  const x = obj(value);
+  const payload = obj(x.assistantPayload ?? x.assistant_payload);
+  return {
+    id: str(x.id) ?? "",
+    role: (str(x.role) ?? "user") as ConversationMessage["role"],
+    content:
+      str(x.userContent) ?? str(x.user_content) ?? str(payload.answer) ?? "",
+    assistantPayload: Object.keys(payload).length
+      ? {
+          answer: str(payload.answer) ?? "",
+          reflectionPrompts: strings(
+            payload.reflectionPrompts ?? payload.reflection_prompts,
+          ),
+          limitations: strings(payload.limitations),
+        }
+      : undefined,
+    createdAt: str(x.createdAt) ?? str(x.created_at),
+  };
+}
+
+export const conversationsApi = {
+  async all(signal?: AbortSignal) {
+    const raw = await api<unknown>("/api/v1/conversations", { signal });
+    return (Array.isArray(raw) ? raw : []).map(conversation);
+  },
+  async create(input: {
+    contextType: ConversationContext;
+    relationshipId?: string | null;
+    title: string;
+  }) {
+    return conversation(
+      await api<unknown>("/api/v1/conversations", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    );
+  },
+  async get(id: string, signal?: AbortSignal) {
+    const raw = obj(
+      await api<unknown>(`/api/v1/conversations/${id}`, { signal }),
+    );
+    return {
+      conversation: conversation(raw.conversation),
+      messages: (Array.isArray(raw.messages) ? raw.messages : []).map(message),
+    };
+  },
+  async send(id: string, content: string) {
+    const raw = obj(
+      await api<unknown>(`/api/v1/conversations/${id}/messages`, {
+        method: "POST",
+        body: JSON.stringify({ content }),
+      }),
+    );
+    return message({ ...raw, role: "assistant" });
+  },
+  feedback: (id: string, rating: "helpful" | "not_helpful") =>
+    api(`/api/v1/messages/${id}/feedback`, {
+      method: "POST",
+      body: JSON.stringify({ rating }),
+    }),
+  archive: (id: string) =>
+    api<void>(`/api/v1/conversations/${id}`, { method: "DELETE" }),
+};

--- a/src/lib/library.ts
+++ b/src/lib/library.ts
@@ -1,0 +1,55 @@
+import { api } from "./api";
+import type { Conversation } from "./conversations";
+
+export type SavedItemType =
+  | "relationship_report"
+  | "blueprint_insight"
+  | "compatibility_guidance";
+export interface SavedItem {
+  id: string;
+  item_type: SavedItemType;
+  relationship_id?: string;
+  blueprint_id?: string;
+  report_id?: string;
+  content_key?: string;
+  created_at?: string;
+}
+export interface ShareCard {
+  id: string;
+  relationship_id?: string;
+  payload: {
+    overall_score?: number;
+    strongest_category?: string;
+    strongest_category_score?: number;
+  };
+  expires_at?: string | null;
+  created_at?: string;
+}
+export interface Library {
+  saved_items: SavedItem[];
+  share_cards: ShareCard[];
+  conversations: Conversation[];
+}
+export const libraryApi = {
+  get: (signal?: AbortSignal) => api<Library>("/api/v1/library", { signal }),
+  save: (input: {
+    item_type: SavedItemType;
+    relationship_id?: string;
+    blueprint_id?: string;
+    report_id?: string;
+    content_key?: string;
+  }) =>
+    api<SavedItem>("/api/v1/saved-items", {
+      method: "POST",
+      body: JSON.stringify(input),
+    }),
+  remove: (id: string) =>
+    api<void>(`/api/v1/saved-items/${id}`, { method: "DELETE" }),
+  createShare: (relationshipId: string) =>
+    api<ShareCard>(`/api/v1/relationships/${relationshipId}/share-cards`, {
+      method: "POST",
+      body: JSON.stringify({ expires_at: null }),
+    }),
+  revokeShare: (id: string) =>
+    api<void>(`/api/v1/share-cards/${id}`, { method: "DELETE" }),
+};

--- a/src/lib/relationships.test.ts
+++ b/src/lib/relationships.test.ts
@@ -1,75 +1,192 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const {apiMock}=vi.hoisted(()=>({apiMock:vi.fn()}));
-vi.mock('./api',async importOriginal=>{
-  const actual=await importOriginal<typeof import('./api')>();
-  return {...actual,api:apiMock};
+const { apiMock } = vi.hoisted(() => ({ apiMock: vi.fn() }));
+vi.mock("./api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api")>();
+  return { ...actual, api: apiMock };
 });
 
-import { blueprintApi, normalizeBlueprintState, normalizePerson, normalizeRelationship, normalizeReport, peopleApi, relationshipsApi, type PersonInput } from './relationships';
+import {
+  blueprintApi,
+  normalizeBlueprintState,
+  normalizePerson,
+  normalizeRelationship,
+  normalizeReport,
+  peopleApi,
+  relationshipsApi,
+  type PersonInput,
+} from "./relationships";
 
-describe('relationship API boundary',()=>{
-  beforeEach(()=>apiMock.mockReset());
+describe("relationship API boundary", () => {
+  beforeEach(() => apiMock.mockReset());
 
-  it('normalizes camelCase and snake_case person fields',()=>{
-    expect(normalizePerson({id:'p1',display_name:'M',relationship_type:'friend',birth_time_status:'unknown'})).toMatchObject({
-      id:'p1',displayName:'M',relationshipType:'friend',birthTimeStatus:'unknown',
+  it("normalizes camelCase and snake_case person fields", () => {
+    expect(
+      normalizePerson({
+        id: "p1",
+        display_name: "M",
+        relationship_type: "friend",
+        birth_time_status: "unknown",
+      }),
+    ).toMatchObject({
+      id: "p1",
+      displayName: "M",
+      relationshipType: "friend",
+      birthTimeStatus: "unknown",
     });
   });
 
-  it('normalizes explicit relationship status without inferring from report fields',()=>{
-    expect(normalizeRelationship({id:'m1',person_id:'p1',status:'ready',compatibility_status:'compatibility_ready',report_status:'report_generating',report:{headline:'Not ready'}})).toMatchObject({
-      status:'ready',compatibilityStatus:'compatibility_ready',reportStatus:'report_generating',
+  it("normalizes explicit relationship status without inferring from report fields", () => {
+    expect(
+      normalizeRelationship({
+        id: "m1",
+        person_id: "p1",
+        status: "ready",
+        compatibility_status: "compatibility_ready",
+        report_status: "report_generating",
+        report: { headline: "Not ready" },
+      }),
+    ).toMatchObject({
+      status: "ready",
+      compatibilityStatus: "compatibility_ready",
+      reportStatus: "report_generating",
     });
   });
 
-  it('normalizes report categories and technical factors',()=>{
-    const report=normalizeReport({overall_score:81,categories:[{key:'communication',label:'Communication',supporting_factors:[{planet_a:'Mercury',planet_b:'Moon',aspect:'trine',orb:2.1}]}]});
+  it("normalizes report categories and technical factors", () => {
+    const report = normalizeReport({
+      overall_score: 81,
+      categories: [
+        {
+          key: "communication",
+          label: "Communication",
+          supporting_factors: [
+            {
+              planet_a: "Mercury",
+              planet_b: "Moon",
+              aspect: "trine",
+              orb: 2.1,
+            },
+          ],
+        },
+      ],
+    });
     expect(report.overallScore).toBe(81);
-    expect(report.categories?.[0].supportingFactors?.[0]).toMatchObject({planetA:'Mercury',planetB:'Moon',aspect:'trine',orb:2.1});
+    expect(report.categories?.[0].supportingFactors?.[0]).toMatchObject({
+      planetA: "Mercury",
+      planetB: "Moon",
+      aspect: "trine",
+      orb: 2.1,
+    });
   });
 
-  it('uses documented People endpoints',async()=>{
+  it("uses documented People endpoints", async () => {
     apiMock.mockResolvedValueOnce([]);
     await peopleApi.all();
-    expect(apiMock).toHaveBeenCalledWith('/api/v1/people',{signal:undefined});
-  });
-
-  it('replaces a person through PATCH and archives through DELETE',async()=>{
-    const input:PersonInput={displayName:'Private person',pronouns:null,relationshipType:'dating',notes:null,birthDate:'1997-08-27',birthTime:null,birthTimeStatus:'unknown',birthTimeAccuracyMinutes:null,birthPlaceLabel:'Dumraon, India',latitude:25.55,longitude:84.14,timezone:'Asia/Kolkata',astrologySystem:'western_tropical'};
-    apiMock.mockResolvedValueOnce({id:'p1',...input}).mockResolvedValueOnce(undefined);
-    await peopleApi.update('p1',input);
-    expect(apiMock).toHaveBeenCalledWith('/api/v1/people/p1',{method:'PATCH',body:JSON.stringify(input)});
-    await peopleApi.archive('p1');
-    expect(apiMock).toHaveBeenLastCalledWith('/api/v1/people/p1',{method:'DELETE'});
-  });
-
-  it('maps explicit Blueprint status and generation endpoints',async()=>{
-    expect(normalizeBlueprintState({status:'ready',blueprint:{archetype:{title:'Connector',summary:'Summary'},emotionalNeeds:[],relationshipStrengths:[],growthEdges:[],datingPatterns:[],supportiveDynamics:[],reflectionPrompts:[],dataQuality:'high'}})).toMatchObject({
-      status:'ready',blueprint:{archetype:{title:'Connector'},dataQuality:'high'},
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/people", {
+      signal: undefined,
     });
-    apiMock.mockResolvedValueOnce({status:'not_generated',blueprint:null}).mockResolvedValueOnce({status:'ready',blueprint:{}});
+  });
+
+  it("replaces a person through PATCH and archives through DELETE", async () => {
+    const input: PersonInput = {
+      displayName: "Private person",
+      pronouns: null,
+      relationshipType: "dating",
+      notes: null,
+      birthDate: "1997-08-27",
+      birthTime: null,
+      birthTimeStatus: "unknown",
+      birthTimeAccuracyMinutes: null,
+      birthPlaceLabel: "Dumraon, India",
+      latitude: 25.55,
+      longitude: 84.14,
+      timezone: "Asia/Kolkata",
+      astrologySystem: "western_tropical",
+      dataConsentAcknowledged: true,
+    };
+    apiMock
+      .mockResolvedValueOnce({ id: "p1", ...input })
+      .mockResolvedValueOnce(undefined);
+    await peopleApi.update("p1", input);
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/people/p1", {
+      method: "PATCH",
+      body: JSON.stringify(input),
+    });
+    await peopleApi.archive("p1");
+    expect(apiMock).toHaveBeenLastCalledWith("/api/v1/people/p1", {
+      method: "DELETE",
+    });
+  });
+
+  it("maps explicit Blueprint status and generation endpoints", async () => {
+    expect(
+      normalizeBlueprintState({
+        status: "ready",
+        blueprint: {
+          archetype: { title: "Connector", summary: "Summary" },
+          emotionalNeeds: [],
+          relationshipStrengths: [],
+          growthEdges: [],
+          datingPatterns: [],
+          supportiveDynamics: [],
+          reflectionPrompts: [],
+          dataQuality: "high",
+        },
+      }),
+    ).toMatchObject({
+      status: "ready",
+      blueprint: { archetype: { title: "Connector" }, dataQuality: "high" },
+    });
+    apiMock
+      .mockResolvedValueOnce({ status: "not_generated", blueprint: null })
+      .mockResolvedValueOnce({ status: "ready", blueprint: {} });
     await blueprintApi.get();
-    expect(apiMock).toHaveBeenCalledWith('/api/v1/me/relationship-blueprint',{signal:undefined});
-    await blueprintApi.generate();
-    expect(apiMock).toHaveBeenLastCalledWith('/api/v1/me/relationship-blueprint/generate',{method:'POST'});
-  });
-
-  it('uses separate deterministic compatibility and narrative generation endpoints',async()=>{
-    apiMock.mockResolvedValue({});
-    await relationshipsApi.calculate('m1','romantic');
-    expect(apiMock).toHaveBeenCalledWith('/api/v1/relationships/m1/compatibility/calculate',{
-      method:'POST',
-      body:JSON.stringify({focus:'romantic'}),
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/me/relationship-blueprint", {
+      signal: undefined,
     });
-    await relationshipsApi.generateReport('m1');
-    expect(apiMock).toHaveBeenLastCalledWith('/api/v1/relationships/m1/report/generate',{method:'POST'});
+    await blueprintApi.generate();
+    expect(apiMock).toHaveBeenLastCalledWith(
+      "/api/v1/me/relationship-blueprint/generate",
+      { method: "POST" },
+    );
   });
 
-  it('creates the relationship with owned profile and person ids in the documented payload',async()=>{
-    const payload={birth_profile_id:'birth-1',person_id:'person-1',relationship_type:'dating' as const,title:'Us'};
-    apiMock.mockResolvedValueOnce({id:'relationship-1',...payload,status:'draft',compatibility_status:'compatibility_not_generated',report_status:'report_not_generated'});
+  it("uses separate deterministic compatibility and narrative generation endpoints", async () => {
+    apiMock.mockResolvedValue({});
+    await relationshipsApi.calculate("m1", "romantic");
+    expect(apiMock).toHaveBeenCalledWith(
+      "/api/v1/relationships/m1/compatibility/calculate",
+      {
+        method: "POST",
+        body: JSON.stringify({ focus: "romantic" }),
+      },
+    );
+    await relationshipsApi.generateReport("m1");
+    expect(apiMock).toHaveBeenLastCalledWith(
+      "/api/v1/relationships/m1/report/generate",
+      { method: "POST" },
+    );
+  });
+
+  it("creates the relationship with owned profile and person ids in the documented payload", async () => {
+    const payload = {
+      birth_profile_id: "birth-1",
+      person_id: "person-1",
+      relationship_type: "dating" as const,
+      title: "Us",
+    };
+    apiMock.mockResolvedValueOnce({
+      id: "relationship-1",
+      ...payload,
+      status: "draft",
+      compatibility_status: "compatibility_not_generated",
+      report_status: "report_not_generated",
+    });
     await relationshipsApi.create(payload);
-    expect(apiMock).toHaveBeenCalledWith('/api/v1/relationships',{method:'POST',body:JSON.stringify(payload)});
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/relationships", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
   });
 });

--- a/src/lib/relationships.ts
+++ b/src/lib/relationships.ts
@@ -1,350 +1,610 @@
-import { api } from './api';
+import { api } from "./api";
 
-export type BirthTimeQuality='exact'|'approximate'|'unknown';
-export type PersonRelationship='partner'|'crush'|'spouse'|'ex'|'friend'|'dating'|'custom';
-export type MatchFocus='general'|'romantic'|'communication'|'long_term';
-export type RelationshipStatus='draft'|'ready'|'analysed'|'archived';
-export type CompatibilityStatus='compatibility_not_generated'|'compatibility_ready';
-export type ReportStatus='report_not_generated'|'report_generating'|'report_ready'|'report_failed';
-export type BlueprintStatus='not_generated'|'generating'|'ready'|'failed';
-export type DataQuality='limited'|'standard'|'high';
+export type BirthTimeQuality = "exact" | "approximate" | "unknown";
+export type PersonRelationship =
+  | "partner"
+  | "crush"
+  | "spouse"
+  | "ex"
+  | "friend"
+  | "dating"
+  | "custom";
+export type MatchFocus = "general" | "romantic" | "communication" | "long_term";
+export type RelationshipStatus = "draft" | "ready" | "analysed" | "archived";
+export type CompatibilityStatus =
+  | "compatibility_not_generated"
+  | "compatibility_calculating"
+  | "compatibility_ready"
+  | "compatibility_failed";
+export type ReportStatus =
+  | "report_not_generated"
+  | "report_generating"
+  | "report_ready"
+  | "report_failed";
+export type BlueprintStatus =
+  | "not_generated"
+  | "generating"
+  | "ready"
+  | "failed";
+export type DataQuality = "limited" | "standard" | "high";
 
 export interface BlueprintInsight {
-  key:string;
-  title:string;
-  summary:string;
-  detail:string;
-  factor_ids:string[];
-  confidence:'low'|'medium'|'high';
+  key: string;
+  title: string;
+  summary: string;
+  detail: string;
+  factor_ids: string[];
+  confidence: "low" | "medium" | "high";
 }
 
 export interface RelationshipBlueprint {
-  archetype:{title:string;summary:string};
-  emotionalNeeds:BlueprintInsight[];
-  affectionStyle?:BlueprintInsight;
-  attractionStyle?:BlueprintInsight;
-  communicationStyle?:BlueprintInsight;
-  conflictStyle?:BlueprintInsight;
-  relationshipStrengths:BlueprintInsight[];
-  growthEdges:BlueprintInsight[];
-  datingPatterns:BlueprintInsight[];
-  supportiveDynamics:BlueprintInsight[];
-  reflectionPrompts:string[];
-  dataQuality:DataQuality;
-  calculationVersion?:string;
-  promptVersion?:string;
+  id?: string;
+  archetype: { title: string; summary: string };
+  emotionalNeeds: BlueprintInsight[];
+  affectionStyle?: BlueprintInsight;
+  attractionStyle?: BlueprintInsight;
+  communicationStyle?: BlueprintInsight;
+  conflictStyle?: BlueprintInsight;
+  relationshipStrengths: BlueprintInsight[];
+  growthEdges: BlueprintInsight[];
+  datingPatterns: BlueprintInsight[];
+  supportiveDynamics: BlueprintInsight[];
+  reflectionPrompts: string[];
+  dataQuality: DataQuality;
+  calculationVersion?: string;
+  promptVersion?: string;
 }
 
 export interface BlueprintState {
-  status:BlueprintStatus;
-  blueprint:RelationshipBlueprint|null;
-  error?:string;
+  status: BlueprintStatus;
+  blueprint: RelationshipBlueprint | null;
+  error?: string;
 }
 
 export interface PersonInput {
-  displayName:string;
-  pronouns:string|null;
-  relationshipType:PersonRelationship;
-  birthDate:string;
-  birthTime:string|null;
-  birthTimeStatus:BirthTimeQuality;
-  birthTimeAccuracyMinutes:number|null;
-  birthPlaceLabel:string;
-  latitude:number;
-  longitude:number;
-  timezone:string;
-  astrologySystem:'western_tropical';
-  notes:string|null;
+  displayName: string;
+  pronouns: string | null;
+  relationshipType: PersonRelationship;
+  birthDate: string;
+  birthTime: string | null;
+  birthTimeStatus: BirthTimeQuality;
+  birthTimeAccuracyMinutes: number | null;
+  birthPlaceLabel: string;
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  astrologySystem: "western_tropical";
+  notes: string | null;
+  dataConsentAcknowledged: boolean;
 }
 
 export interface PrivatePerson extends PersonInput {
-  id:string;
-  createdAt?:string;
-  updatedAt?:string;
-  chartStatus?:string;
-  dataQuality?:string;
+  id: string;
+  dataConsentAcknowledgedAt?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  chartStatus?: string;
+  dataQuality?: string;
 }
 
 export interface CompatibilityFactor {
-  title?:string;
-  label?:string;
-  description?:string;
-  interpretation?:string;
-  direction?:string;
-  planetA?:string;
-  planetB?:string;
-  aspect?:string;
-  orb?:number;
+  title?: string;
+  label?: string;
+  description?: string;
+  interpretation?: string;
+  direction?: string;
+  planetA?: string;
+  planetB?: string;
+  aspect?: string;
+  orb?: number;
 }
 
 export interface CompatibilityCategory {
-  key:string;
-  label:string;
-  score?:number;
-  headline?:string;
-  interpretation?:string;
-  dataQuality?:string;
-  qualitativeLabel?:string;
-  confidence?:'low'|'medium'|'high';
-  supportingFactorIds?:string[];
-  challengingFactorIds?:string[];
-  supportingFactors?:CompatibilityFactor[];
-  challengingFactors?:CompatibilityFactor[];
+  key: string;
+  label: string;
+  score?: number;
+  headline?: string;
+  interpretation?: string;
+  dataQuality?: string;
+  qualitativeLabel?: string;
+  confidence?: "low" | "medium" | "high";
+  supportingFactorIds?: string[];
+  challengingFactorIds?: string[];
+  supportingFactors?: CompatibilityFactor[];
+  challengingFactors?: CompatibilityFactor[];
 }
 
 export interface CompatibilityReport {
-  id?:string;
-  status?:string;
-  headline?:string;
-  summary?:string;
-  overallScore?:number;
-  qualitativeLabel?:string;
-  dataQuality?:string;
-  strongestConnection?:{title?:string;body?:string;factorIds?:string[]};
-  primaryFriction?:{title?:string;body?:string;factorIds?:string[]};
-  categories?:CompatibilityCategory[];
-  practicalGuidance?:Array<{title?:string;body:string;factorIds?:string[]}>;
-  reflectionPrompts?:string[];
-  factors?:CompatibilityFactor[];
-  limitations?:string[];
-  canRegenerate?:boolean;
-  regenerationReason?:string;
+  id?: string;
+  status?: string;
+  headline?: string;
+  summary?: string;
+  overallScore?: number;
+  qualitativeLabel?: string;
+  dataQuality?: string;
+  strongestConnection?: { title?: string; body?: string; factorIds?: string[] };
+  primaryFriction?: { title?: string; body?: string; factorIds?: string[] };
+  categories?: CompatibilityCategory[];
+  practicalGuidance?: Array<{
+    title?: string;
+    body: string;
+    factorIds?: string[];
+  }>;
+  reflectionPrompts?: string[];
+  factors?: CompatibilityFactor[];
+  limitations?: string[];
+  canRegenerate?: boolean;
+  regenerationReason?: string;
 }
 
 export interface CompatibilityAnalysis {
-  overall?:number;
-  qualitativeLabel?:string;
-  categories:CompatibilityCategory[];
-  strengths:CompatibilityFactor[];
-  challenges:CompatibilityFactor[];
-  mixedDynamics:CompatibilityFactor[];
-  aspects:CompatibilityFactor[];
-  exclusions:string[];
-  dataQuality?:string;
-  calculationVersion?:string;
-  interpretationVersion?:string;
+  overall?: number;
+  qualitativeLabel?: string;
+  categories: CompatibilityCategory[];
+  strengths: CompatibilityFactor[];
+  challenges: CompatibilityFactor[];
+  mixedDynamics: CompatibilityFactor[];
+  aspects: CompatibilityFactor[];
+  exclusions: string[];
+  dataQuality?: string;
+  calculationVersion?: string;
+  interpretationVersion?: string;
 }
 
 export interface Relationship {
-  id:string;
-  birthProfileId:string;
-  personId:string;
-  focus?:MatchFocus;
-  status:RelationshipStatus;
-  compatibilityStatus:CompatibilityStatus;
-  reportStatus:ReportStatus;
-  title?:string|null;
-  relationshipType?:PersonRelationship;
-  person?:PrivatePerson;
-  headline?:string;
-  qualitativeLabel?:string;
-  dataQuality?:string;
-  score?:number;
-  report?:CompatibilityReport;
-  updatedAt?:string;
+  id: string;
+  birthProfileId: string;
+  personId: string;
+  focus?: MatchFocus;
+  status: RelationshipStatus;
+  compatibilityStatus: CompatibilityStatus;
+  reportStatus: ReportStatus;
+  title?: string | null;
+  relationshipType?: PersonRelationship;
+  person?: PrivatePerson;
+  headline?: string;
+  qualitativeLabel?: string;
+  dataQuality?: string;
+  score?: number;
+  report?: CompatibilityReport;
+  updatedAt?: string;
 }
 
-const record=(value:unknown):Record<string,unknown>=>typeof value==='object'&&value!==null?value as Record<string,unknown>:{};
-const text=(value:unknown)=>typeof value==='string'?value:undefined;
-const number=(value:unknown)=>typeof value==='number'?value:undefined;
-const array=(value:unknown):unknown[]=>Array.isArray(value)?value:[];
+const record = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : {};
+const text = (value: unknown) =>
+  typeof value === "string" ? value : undefined;
+const number = (value: unknown) =>
+  typeof value === "number" ? value : undefined;
+const array = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : [];
 
-export function normalizePerson(value:unknown):PrivatePerson {
-  const item=record(value);
+export function normalizePerson(value: unknown): PrivatePerson {
+  const item = record(value);
   return {
-    id:text(item.id)??'',
-    displayName:text(item.displayName)??text(item.display_name)??'Private person',
-    pronouns:text(item.pronouns)??null,
-    relationshipType:(text(item.relationshipType)??text(item.relationship_type)??'custom') as PersonRelationship,
-    birthDate:text(item.birthDate)??text(item.birth_date)??'',
-    birthTime:text(item.birthTime)??text(item.birth_time)??null,
-    birthTimeStatus:(text(item.birthTimeStatus)??text(item.birth_time_status)??'unknown') as BirthTimeQuality,
-    birthTimeAccuracyMinutes:number(item.birthTimeAccuracyMinutes)??number(item.birth_time_accuracy_minutes)??null,
-    birthPlaceLabel:text(item.birthPlaceLabel)??text(item.birth_place_label)??'Private location',
-    latitude:number(item.latitude)??0,
-    longitude:number(item.longitude)??0,
-    timezone:text(item.timezone)??'UTC',
-    astrologySystem:'western_tropical',
-    notes:text(item.notes)??null,
-    createdAt:text(item.createdAt)??text(item.created_at),
-    updatedAt:text(item.updatedAt)??text(item.updated_at),
-    chartStatus:text(item.chartStatus)??text(item.chart_status),
-    dataQuality:text(item.dataQuality)??text(item.data_quality),
+    id: text(item.id) ?? "",
+    displayName:
+      text(item.displayName) ?? text(item.display_name) ?? "Private person",
+    pronouns: text(item.pronouns) ?? null,
+    relationshipType: (text(item.relationshipType) ??
+      text(item.relationship_type) ??
+      "custom") as PersonRelationship,
+    birthDate: text(item.birthDate) ?? text(item.birth_date) ?? "",
+    birthTime: text(item.birthTime) ?? text(item.birth_time) ?? null,
+    birthTimeStatus: (text(item.birthTimeStatus) ??
+      text(item.birth_time_status) ??
+      "unknown") as BirthTimeQuality,
+    birthTimeAccuracyMinutes:
+      number(item.birthTimeAccuracyMinutes) ??
+      number(item.birth_time_accuracy_minutes) ??
+      null,
+    birthPlaceLabel:
+      text(item.birthPlaceLabel) ??
+      text(item.birth_place_label) ??
+      "Private location",
+    latitude: number(item.latitude) ?? 0,
+    longitude: number(item.longitude) ?? 0,
+    timezone: text(item.timezone) ?? "UTC",
+    astrologySystem: "western_tropical",
+    notes: text(item.notes) ?? null,
+    dataConsentAcknowledged:
+      item.dataConsentAcknowledged === true ||
+      item.data_consent_acknowledged === true,
+    dataConsentAcknowledgedAt:
+      text(item.dataConsentAcknowledgedAt) ??
+      text(item.data_consent_acknowledged_at),
+    createdAt: text(item.createdAt) ?? text(item.created_at),
+    updatedAt: text(item.updatedAt) ?? text(item.updated_at),
+    chartStatus: text(item.chartStatus) ?? text(item.chart_status),
+    dataQuality: text(item.dataQuality) ?? text(item.data_quality),
   };
 }
 
-function normalizeCategory(value:unknown,index:number):CompatibilityCategory {
-  const item=record(value);
+function normalizeCategory(
+  value: unknown,
+  index: number,
+): CompatibilityCategory {
+  const item = record(value);
   return {
-    key:text(item.key)??text(item.category)??`category_${index}`,
-    label:text(item.label)??text(item.title)??text(item.category)??`Category ${index+1}`,
-    score:number(item.score),
-    headline:text(item.headline),
-    interpretation:text(item.interpretation)??text(item.description),
-    dataQuality:text(item.dataQuality)??text(item.data_quality),
-    qualitativeLabel:text(item.qualitativeLabel)??text(item.qualitative_label),
-    confidence:text(item.confidence) as CompatibilityCategory['confidence'],
-    supportingFactorIds:array(item.supportingFactorIds??item.supporting_factor_ids).filter((x):x is string=>typeof x==='string'),
-    challengingFactorIds:array(item.challengingFactorIds??item.challenging_factor_ids).filter((x):x is string=>typeof x==='string'),
-    supportingFactors:array(item.supportingFactors??item.supporting_factors).map(normalizeFactor),
-    challengingFactors:array(item.challengingFactors??item.challenging_factors).map(normalizeFactor),
+    key: text(item.key) ?? text(item.category) ?? `category_${index}`,
+    label:
+      text(item.label) ??
+      text(item.title) ??
+      text(item.category) ??
+      `Category ${index + 1}`,
+    score: number(item.score),
+    headline: text(item.headline),
+    interpretation: text(item.interpretation) ?? text(item.description),
+    dataQuality: text(item.dataQuality) ?? text(item.data_quality),
+    qualitativeLabel:
+      text(item.qualitativeLabel) ?? text(item.qualitative_label),
+    confidence: text(item.confidence) as CompatibilityCategory["confidence"],
+    supportingFactorIds: array(
+      item.supportingFactorIds ?? item.supporting_factor_ids,
+    ).filter((x): x is string => typeof x === "string"),
+    challengingFactorIds: array(
+      item.challengingFactorIds ?? item.challenging_factor_ids,
+    ).filter((x): x is string => typeof x === "string"),
+    supportingFactors: array(
+      item.supportingFactors ?? item.supporting_factors,
+    ).map(normalizeFactor),
+    challengingFactors: array(
+      item.challengingFactors ?? item.challenging_factors,
+    ).map(normalizeFactor),
   };
 }
 
-function normalizeFactor(value:unknown):CompatibilityFactor {
-  const item=record(value);
+function normalizeFactor(value: unknown): CompatibilityFactor {
+  const item = record(value);
   return {
-    title:text(item.title),
-    label:text(item.label),
-    description:text(item.description),
-    interpretation:text(item.interpretation),
-    direction:text(item.direction),
-    planetA:text(item.planetA)??text(item.planet_a),
-    planetB:text(item.planetB)??text(item.planet_b),
-    aspect:text(item.aspect),
-    orb:number(item.orb),
+    title: text(item.title),
+    label: text(item.label),
+    description: text(item.description),
+    interpretation: text(item.interpretation),
+    direction: text(item.direction),
+    planetA: text(item.planetA) ?? text(item.planet_a),
+    planetB: text(item.planetB) ?? text(item.planet_b),
+    aspect: text(item.aspect),
+    orb: number(item.orb),
   };
 }
 
-export function normalizeReport(value:unknown):CompatibilityReport {
-  const envelope=record(value);
-  const item=record(envelope.report??value);
-  const quality=record(item.dataQuality??item.data_quality);
-  const connection=record(item.strongestConnection??item.strongest_connection);
-  const friction=record(item.primaryFriction??item.primary_friction);
+export function normalizeReport(value: unknown): CompatibilityReport {
+  const envelope = record(value);
+  const item = record(envelope.report ?? value);
+  const quality = record(item.dataQuality ?? item.data_quality);
+  const connection = record(
+    item.strongestConnection ?? item.strongest_connection,
+  );
+  const friction = record(item.primaryFriction ?? item.primary_friction);
   return {
-    id:text(item.id),
-    status:text(item.status),
-    headline:text(item.headline)??text(item.overallHeadline)??text(item.overall_headline),
-    summary:text(item.summary),
-    overallScore:number(item.overallScore)??number(item.overall_score)??number(item.score),
-    qualitativeLabel:text(item.qualitativeLabel)??text(item.qualitative_label),
-    dataQuality:text(item.dataQuality)??text(item.data_quality)??text(quality.level),
-    strongestConnection:Object.keys(connection).length?{title:text(connection.title),body:text(connection.body),factorIds:array(connection.factorIds??connection.factor_ids).filter((x):x is string=>typeof x==='string')}:undefined,
-    primaryFriction:Object.keys(friction).length?{title:text(friction.title),body:text(friction.body),factorIds:array(friction.factorIds??friction.factor_ids).filter((x):x is string=>typeof x==='string')}:undefined,
-    categories:array(item.categories).map(normalizeCategory),
-    practicalGuidance:array(item.practicalGuidance??item.practical_guidance).map(value=>{
-      if(typeof value==='string')return {body:value};
-      const guidance=record(value);
-      return {title:text(guidance.title),body:text(guidance.body)??'',factorIds:array(guidance.factorIds??guidance.factor_ids).filter((x):x is string=>typeof x==='string')};
+    id: text(envelope.id) ?? text(item.id),
+    status: text(item.status),
+    headline:
+      text(item.headline) ??
+      text(item.overallHeadline) ??
+      text(item.overall_headline),
+    summary: text(item.summary),
+    overallScore:
+      number(item.overallScore) ??
+      number(item.overall_score) ??
+      number(item.score),
+    qualitativeLabel:
+      text(item.qualitativeLabel) ?? text(item.qualitative_label),
+    dataQuality:
+      text(item.dataQuality) ?? text(item.data_quality) ?? text(quality.level),
+    strongestConnection: Object.keys(connection).length
+      ? {
+          title: text(connection.title),
+          body: text(connection.body),
+          factorIds: array(
+            connection.factorIds ?? connection.factor_ids,
+          ).filter((x): x is string => typeof x === "string"),
+        }
+      : undefined,
+    primaryFriction: Object.keys(friction).length
+      ? {
+          title: text(friction.title),
+          body: text(friction.body),
+          factorIds: array(friction.factorIds ?? friction.factor_ids).filter(
+            (x): x is string => typeof x === "string",
+          ),
+        }
+      : undefined,
+    categories: array(item.categories).map(normalizeCategory),
+    practicalGuidance: array(
+      item.practicalGuidance ?? item.practical_guidance,
+    ).map((value) => {
+      if (typeof value === "string") return { body: value };
+      const guidance = record(value);
+      return {
+        title: text(guidance.title),
+        body: text(guidance.body) ?? "",
+        factorIds: array(guidance.factorIds ?? guidance.factor_ids).filter(
+          (x): x is string => typeof x === "string",
+        ),
+      };
     }),
-    reflectionPrompts:array(item.reflectionPrompts??item.reflection_prompts).filter((x):x is string=>typeof x==='string'),
-    factors:array(item.factors).map(normalizeFactor),
-    limitations:[...array(quality.limitations),...array(item.limitations)].filter((x):x is string=>typeof x==='string'),
-    canRegenerate:item.canRegenerate===true||item.can_regenerate===true,
-    regenerationReason:text(item.regenerationReason)??text(item.regeneration_reason),
+    reflectionPrompts: array(
+      item.reflectionPrompts ?? item.reflection_prompts,
+    ).filter((x): x is string => typeof x === "string"),
+    factors: array(item.factors).map(normalizeFactor),
+    limitations: [
+      ...array(quality.limitations),
+      ...array(item.limitations),
+    ].filter((x): x is string => typeof x === "string"),
+    canRegenerate: item.canRegenerate === true || item.can_regenerate === true,
+    regenerationReason:
+      text(item.regenerationReason) ?? text(item.regeneration_reason),
   };
 }
 
-export function normalizeCompatibility(value:unknown):CompatibilityAnalysis {
-  const item=record(value);
-  const overall=record(item.overall);
+export function normalizeCompatibility(value: unknown): CompatibilityAnalysis {
+  const item = record(value);
+  const overall = record(item.overall);
   return {
-    overall:number(item.overall)??number(overall.score),
-    qualitativeLabel:text(item.qualitativeLabel)??text(item.qualitative_label)??text(overall.qualitativeLabel)??text(overall.qualitative_label),
-    categories:array(item.categories).map(normalizeCategory),
-    strengths:array(item.strengths).map(normalizeFactor),
-    challenges:array(item.challenges).map(normalizeFactor),
-    mixedDynamics:array(item.mixedDynamics??item.mixed_dynamics).map(normalizeFactor),
-    aspects:array(item.aspects).map(normalizeFactor),
-    exclusions:array(item.exclusions).filter((x):x is string=>typeof x==='string'),
-    dataQuality:text(item.dataQuality)??text(item.data_quality)??text(record(item.data_quality).level),
-    calculationVersion:text(item.calculationVersion)??text(item.calculation_version),
-    interpretationVersion:text(item.interpretationVersion)??text(item.interpretation_version),
+    overall: number(item.overall) ?? number(overall.score),
+    qualitativeLabel:
+      text(item.qualitativeLabel) ??
+      text(item.qualitative_label) ??
+      text(overall.qualitativeLabel) ??
+      text(overall.qualitative_label),
+    categories: array(item.categories).map(normalizeCategory),
+    strengths: array(item.strengths).map(normalizeFactor),
+    challenges: array(item.challenges).map(normalizeFactor),
+    mixedDynamics: array(item.mixedDynamics ?? item.mixed_dynamics).map(
+      normalizeFactor,
+    ),
+    aspects: array(item.aspects).map(normalizeFactor),
+    exclusions: array(item.exclusions).filter(
+      (x): x is string => typeof x === "string",
+    ),
+    dataQuality:
+      text(item.dataQuality) ??
+      text(item.data_quality) ??
+      text(record(item.data_quality).level),
+    calculationVersion:
+      text(item.calculationVersion) ?? text(item.calculation_version),
+    interpretationVersion:
+      text(item.interpretationVersion) ?? text(item.interpretation_version),
   };
 }
 
-export function normalizeRelationship(value:unknown):Relationship {
-  const item=record(value);
-  const personValue=item.person??item.private_person;
+export function normalizeRelationship(value: unknown): Relationship {
+  const item = record(value);
+  const personValue = item.person ?? item.private_person;
   return {
-    id:text(item.id)??'',
-    birthProfileId:text(item.birthProfileId)??text(item.birth_profile_id)??'',
-    personId:text(item.personId)??text(item.person_id)??text(record(personValue).id)??'',
-    focus:text(item.focus) as MatchFocus|undefined,
-    status:(text(item.status)??'draft') as RelationshipStatus,
-    compatibilityStatus:(text(item.compatibilityStatus)??text(item.compatibility_status)??'compatibility_not_generated') as CompatibilityStatus,
-    reportStatus:(text(item.reportStatus)??text(item.report_status)??'report_not_generated') as ReportStatus,
-    title:text(item.title)??null,
-    relationshipType:(text(item.relationshipType)??text(item.relationship_type)) as PersonRelationship|undefined,
-    person:personValue?normalizePerson(personValue):undefined,
-    headline:text(item.headline),
-    qualitativeLabel:text(item.qualitativeLabel)??text(item.qualitative_label),
-    dataQuality:text(item.dataQuality)??text(item.data_quality),
-    score:number(item.score),
-    report:item.report?normalizeReport(item.report):undefined,
-    updatedAt:text(item.updatedAt)??text(item.updated_at),
+    id: text(item.id) ?? "",
+    birthProfileId:
+      text(item.birthProfileId) ?? text(item.birth_profile_id) ?? "",
+    personId:
+      text(item.personId) ??
+      text(item.person_id) ??
+      text(record(personValue).id) ??
+      "",
+    focus: text(item.focus) as MatchFocus | undefined,
+    status: (text(item.status) ?? "draft") as RelationshipStatus,
+    compatibilityStatus: (text(item.compatibilityStatus) ??
+      text(item.compatibility_status) ??
+      "compatibility_not_generated") as CompatibilityStatus,
+    reportStatus: (text(item.reportStatus) ??
+      text(item.report_status) ??
+      "report_not_generated") as ReportStatus,
+    title: text(item.title) ?? null,
+    relationshipType: (text(item.relationshipType) ??
+      text(item.relationship_type)) as PersonRelationship | undefined,
+    person: personValue ? normalizePerson(personValue) : undefined,
+    headline: text(item.headline),
+    qualitativeLabel:
+      text(item.qualitativeLabel) ?? text(item.qualitative_label),
+    dataQuality: text(item.dataQuality) ?? text(item.data_quality),
+    score: number(item.score),
+    report: item.report ? normalizeReport(item.report) : undefined,
+    updatedAt: text(item.updatedAt) ?? text(item.updated_at),
   };
 }
 
-function listPayload(value:unknown){
-  if(Array.isArray(value))return value;
-  const item=record(value);
-  return array(item.items??item.people??item.relationships??item.data);
+function listPayload(value: unknown) {
+  if (Array.isArray(value)) return value;
+  const item = record(value);
+  return array(item.items ?? item.people ?? item.relationships ?? item.data);
 }
 
-export const relationshipQueryKeys={
-  blueprint:['relationship-blueprint'] as const,
-  people:['people'] as const,
-  person:(id:string)=>['people',id] as const,
-  relationships:['relationships'] as const,
-  relationship:(id:string)=>['relationships',id] as const,
-  compatibility:(id:string)=>['relationships',id,'compatibility'] as const,
-  report:(id:string)=>['relationships',id,'report'] as const,
+export const relationshipQueryKeys = {
+  blueprint: ["relationship-blueprint"] as const,
+  people: ["people"] as const,
+  person: (id: string) => ["people", id] as const,
+  relationships: ["relationships"] as const,
+  relationship: (id: string) => ["relationships", id] as const,
+  compatibility: (id: string) =>
+    ["relationships", id, "compatibility"] as const,
+  report: (id: string) => ["relationships", id, "report"] as const,
 };
 
-export function normalizeBlueprintState(value:unknown):BlueprintState {
-  const item=record(value);
-  const status=(text(item.status)??(item.blueprint||item.archetype?'ready':'not_generated')) as BlueprintStatus;
-  const raw=record(item.blueprint??(status==='ready'?item:null));
-  const insight=(value:unknown):BlueprintInsight|undefined=>{
-    const entry=record(value);
-    if(!text(entry.key)||!text(entry.title))return undefined;
-    return {key:text(entry.key)!,title:text(entry.title)!,summary:text(entry.summary)??'',detail:text(entry.detail)??'',factor_ids:array(entry.factor_ids).filter((x):x is string=>typeof x==='string'),confidence:(text(entry.confidence)??'medium') as BlueprintInsight['confidence']};
+export function normalizeBlueprintState(value: unknown): BlueprintState {
+  const item = record(value);
+  const status = (text(item.status) ??
+    (item.blueprint || item.archetype
+      ? "ready"
+      : "not_generated")) as BlueprintStatus;
+  const raw = record(item.blueprint ?? (status === "ready" ? item : null));
+  const insight = (value: unknown): BlueprintInsight | undefined => {
+    const entry = record(value);
+    if (!text(entry.key) || !text(entry.title)) return undefined;
+    return {
+      key: text(entry.key)!,
+      title: text(entry.title)!,
+      summary: text(entry.summary) ?? "",
+      detail: text(entry.detail) ?? "",
+      factor_ids: array(entry.factor_ids).filter(
+        (x): x is string => typeof x === "string",
+      ),
+      confidence: (text(entry.confidence) ??
+        "medium") as BlueprintInsight["confidence"],
+    };
   };
-  const insights=(value:unknown)=>array(value).map(insight).filter((x):x is BlueprintInsight=>Boolean(x));
-  const blueprint=status==='ready'?{
-    archetype:{title:text(record(raw.archetype).title)??'Your relationship blueprint',summary:text(record(raw.archetype).summary)??''},
-    emotionalNeeds:insights(raw.emotionalNeeds??raw.emotional_needs),
-    affectionStyle:insight(raw.affectionStyle??raw.affection_style),
-    attractionStyle:insight(raw.attractionStyle??raw.attraction_style),
-    communicationStyle:insight(raw.communicationStyle??raw.communication_style),
-    conflictStyle:insight(raw.conflictStyle??raw.conflict_style),
-    relationshipStrengths:insights(raw.relationshipStrengths??raw.relationship_strengths),
-    growthEdges:insights(raw.growthEdges??raw.growth_edges),
-    datingPatterns:insights(raw.datingPatterns??raw.dating_patterns),
-    supportiveDynamics:insights(raw.supportiveDynamics??raw.supportive_dynamics),
-    reflectionPrompts:array(raw.reflectionPrompts??raw.reflection_prompts).filter((x):x is string=>typeof x==='string'),
-    dataQuality:(text(raw.dataQuality)??text(raw.data_quality)??'limited') as DataQuality,
-    calculationVersion:text(raw.calculationVersion)??text(raw.calculation_version),
-    promptVersion:text(raw.promptVersion)??text(raw.prompt_version),
-  }:null;
-  return {status,blueprint,error:text(item.error)};
+  const insights = (value: unknown) =>
+    array(value)
+      .map(insight)
+      .filter((x): x is BlueprintInsight => Boolean(x));
+  const blueprint =
+    status === "ready"
+      ? {
+          id: text(raw.id),
+          archetype: {
+            title:
+              text(record(raw.archetype).title) ??
+              "Your relationship blueprint",
+            summary: text(record(raw.archetype).summary) ?? "",
+          },
+          emotionalNeeds: insights(raw.emotionalNeeds ?? raw.emotional_needs),
+          affectionStyle: insight(raw.affectionStyle ?? raw.affection_style),
+          attractionStyle: insight(raw.attractionStyle ?? raw.attraction_style),
+          communicationStyle: insight(
+            raw.communicationStyle ?? raw.communication_style,
+          ),
+          conflictStyle: insight(raw.conflictStyle ?? raw.conflict_style),
+          relationshipStrengths: insights(
+            raw.relationshipStrengths ?? raw.relationship_strengths,
+          ),
+          growthEdges: insights(raw.growthEdges ?? raw.growth_edges),
+          datingPatterns: insights(raw.datingPatterns ?? raw.dating_patterns),
+          supportiveDynamics: insights(
+            raw.supportiveDynamics ?? raw.supportive_dynamics,
+          ),
+          reflectionPrompts: array(
+            raw.reflectionPrompts ?? raw.reflection_prompts,
+          ).filter((x): x is string => typeof x === "string"),
+          dataQuality: (text(raw.dataQuality) ??
+            text(raw.data_quality) ??
+            "limited") as DataQuality,
+          calculationVersion:
+            text(raw.calculationVersion) ?? text(raw.calculation_version),
+          promptVersion: text(raw.promptVersion) ?? text(raw.prompt_version),
+        }
+      : null;
+  return { status, blueprint, error: text(item.error) };
 }
 
-export const blueprintApi={
-  async get(signal?:AbortSignal){return normalizeBlueprintState(await api<unknown>('/api/v1/me/relationship-blueprint',{signal}))},
-  async generate(){return normalizeBlueprintState(await api<unknown>('/api/v1/me/relationship-blueprint/generate',{method:'POST'}))},
-  async regenerate(){return normalizeBlueprintState(await api<unknown>('/api/v1/me/relationship-blueprint/regenerate',{method:'POST'}))},
+export const blueprintApi = {
+  async get(signal?: AbortSignal) {
+    return normalizeBlueprintState(
+      await api<unknown>("/api/v1/me/relationship-blueprint", { signal }),
+    );
+  },
+  async generate() {
+    return normalizeBlueprintState(
+      await api<unknown>("/api/v1/me/relationship-blueprint/generate", {
+        method: "POST",
+      }),
+    );
+  },
+  async regenerate() {
+    return normalizeBlueprintState(
+      await api<unknown>("/api/v1/me/relationship-blueprint/regenerate", {
+        method: "POST",
+      }),
+    );
+  },
 };
 
-export const peopleApi={
-  async all(signal?:AbortSignal){return listPayload(await api<unknown>('/api/v1/people',{signal})).map(normalizePerson)},
-  async get(id:string,signal?:AbortSignal){return normalizePerson(await api<unknown>(`/api/v1/people/${id}`,{signal}))},
-  async create(input:PersonInput){return normalizePerson(await api<unknown>('/api/v1/people',{method:'POST',body:JSON.stringify(input)}))},
-  async update(id:string,input:PersonInput){return normalizePerson(await api<unknown>(`/api/v1/people/${id}`,{method:'PATCH',body:JSON.stringify(input)}))},
-  archive:(id:string)=>api<void>(`/api/v1/people/${id}`,{method:'DELETE'}),
+export const peopleApi = {
+  async all(signal?: AbortSignal) {
+    return listPayload(await api<unknown>("/api/v1/people", { signal })).map(
+      normalizePerson,
+    );
+  },
+  async get(id: string, signal?: AbortSignal) {
+    return normalizePerson(
+      await api<unknown>(`/api/v1/people/${id}`, { signal }),
+    );
+  },
+  async create(input: PersonInput) {
+    return normalizePerson(
+      await api<unknown>("/api/v1/people", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    );
+  },
+  async update(id: string, input: PersonInput) {
+    return normalizePerson(
+      await api<unknown>(`/api/v1/people/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify(input),
+      }),
+    );
+  },
+  archive: (id: string) =>
+    api<void>(`/api/v1/people/${id}`, { method: "DELETE" }),
 };
 
-export const relationshipsApi={
-  async all(signal?:AbortSignal){return listPayload(await api<unknown>('/api/v1/relationships',{signal})).map(normalizeRelationship)},
-  async get(id:string,signal?:AbortSignal){return normalizeRelationship(await api<unknown>(`/api/v1/relationships/${id}`,{signal}))},
-  async create(input:{birth_profile_id:string;person_id:string;relationship_type:PersonRelationship;title:string|null}){return normalizeRelationship(await api<unknown>('/api/v1/relationships',{method:'POST',body:JSON.stringify(input)}))},
-  async update(id:string,patch:{relationship_type?:PersonRelationship;title?:string|null}){return normalizeRelationship(await api<unknown>(`/api/v1/relationships/${id}`,{method:'PATCH',body:JSON.stringify(patch)}))},
-  async calculate(id:string,focus:MatchFocus){return api<unknown>(`/api/v1/relationships/${id}/compatibility/calculate`,{method:'POST',body:JSON.stringify({focus})})},
-  async compatibility(id:string,signal?:AbortSignal){return normalizeCompatibility(await api<unknown>(`/api/v1/relationships/${id}/compatibility`,{signal}))},
-  generateReport:(id:string)=>api<unknown>(`/api/v1/relationships/${id}/report/generate`,{method:'POST'}),
-  async report(id:string,signal?:AbortSignal){return normalizeReport(await api<unknown>(`/api/v1/relationships/${id}/report`,{signal}))},
-  async regenerateReport(id:string){return normalizeReport(await api<unknown>(`/api/v1/relationships/${id}/report/regenerate`,{method:'POST'}))},
-  archive:(id:string)=>api<void>(`/api/v1/relationships/${id}`,{method:'DELETE'}),
+export const relationshipsApi = {
+  async all(signal?: AbortSignal) {
+    return listPayload(
+      await api<unknown>("/api/v1/relationships", { signal }),
+    ).map(normalizeRelationship);
+  },
+  async get(id: string, signal?: AbortSignal) {
+    return normalizeRelationship(
+      await api<unknown>(`/api/v1/relationships/${id}`, { signal }),
+    );
+  },
+  async create(input: {
+    birth_profile_id: string;
+    person_id: string;
+    relationship_type: PersonRelationship;
+    title: string | null;
+  }) {
+    return normalizeRelationship(
+      await api<unknown>("/api/v1/relationships", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    );
+  },
+  async update(
+    id: string,
+    patch: { relationship_type?: PersonRelationship; title?: string | null },
+  ) {
+    return normalizeRelationship(
+      await api<unknown>(`/api/v1/relationships/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify(patch),
+      }),
+    );
+  },
+  async calculate(id: string, focus: MatchFocus) {
+    return api<unknown>(`/api/v1/relationships/${id}/compatibility/calculate`, {
+      method: "POST",
+      body: JSON.stringify({ focus }),
+    });
+  },
+  async compatibility(id: string, signal?: AbortSignal) {
+    return normalizeCompatibility(
+      await api<unknown>(`/api/v1/relationships/${id}/compatibility`, {
+        signal,
+      }),
+    );
+  },
+  generateReport: (id: string) =>
+    api<unknown>(`/api/v1/relationships/${id}/report/generate`, {
+      method: "POST",
+    }),
+  async report(id: string, signal?: AbortSignal) {
+    return normalizeReport(
+      await api<unknown>(`/api/v1/relationships/${id}/report`, { signal }),
+    );
+  },
+  async regenerateReport(id: string) {
+    return normalizeReport(
+      await api<unknown>(`/api/v1/relationships/${id}/report/regenerate`, {
+        method: "POST",
+      }),
+    );
+  },
+  archive: (id: string) =>
+    api<void>(`/api/v1/relationships/${id}`, { method: "DELETE" }),
 };


### PR DESCRIPTION
## Summary
- connect Ask AstroMatch to backend conversations with personal, general, and relationship context plus feedback
- add the unified Saved library for report references, conversations, and safe private share cards
- add required third-party birth-data consent, expanded compatibility states, report saving, relationship sharing, export, and account deletion
- protect authenticated web routes and replace the illustrative home match with live account and relationship data
- preserve backend error codes so clients can respond to consent, deleted-account, quota, and provider states

## Backend dependency
Depends on astromatch/astro-backend#16 (`agent/backend-prd-alignment`). Merge/deploy that backend contract before deploying this web branch.

## Validation
- `npm run typecheck`
- `npm test -- --run` (33 tests)
- `npm run lint`
- `npm run build`

## Notes
- Relationship share cards remain private references; the web only invokes the device share sheet or copies a safe summary. It does not expose a public URL.
- Existing private-person records without consent require explicit acknowledgement when edited before relationship analysis.
- The production build succeeds with the existing Vite bundle-size warning; code-splitting can be handled separately.
