### PR TITLE
Add matchmaking safety and sparse-market UX

### DIFF
--- a/src/DatingProfilePage.tsx
+++ b/src/DatingProfilePage.tsx
@@ -11,7 +11,7 @@ import { searchPlaces, type PlaceResult } from './lib/geocoding';
 
 const promptIdeas=['The quickest way to my heart is…','A perfect Sunday looks like…','I’ll never stop talking about…'];
 const questionIdeas=['What are you looking for right now?','What makes a relationship feel safe?'];
-const emptyProfile:DatingProfile={username:null,bio:null,max_distance_km:null,preferences:{},interested_in:[],hobbies:[],interests:[],visibility:'matches',discovery_paused:false,discovery_active:false,relationship_intent:null,min_age:18,max_age:50,location_label:null,has_discovery_location:false,allow_match_to_message_first:true,review_status:'approved',prompts:[],questions:[],photos:[]};
+const emptyProfile:DatingProfile={username:null,bio:null,max_distance_km:null,preferences:{},interested_in:[],hobbies:[],interests:[],visibility:'matches',discovery_paused:false,discovery_active:false,relationship_intent:null,min_age:18,max_age:50,location_label:null,has_discovery_location:false,allow_match_to_message_first:true,review_status:'pending',verification_status:'unverified',prompts:[],questions:[],photos:[]};
 const commaList=(value:FormDataEntryValue|null)=>String(value??'').split(',').map(item=>item.trim()).filter(Boolean);
 
 function errorMessage(error:unknown,fallback:string){
@@ -169,6 +169,15 @@ export function DatingProfilePage(){
     }
   }
 
+  async function submitReview(){
+    try{await datingProfileApi.submitReview();await load();setMessage('Profile submitted for review. Discovery stays off until approval.')}catch(error){setMessage(errorMessage(error,'We couldn’t submit your profile.'))}
+  }
+  async function appeal(){
+    const reason=prompt('Tell the review team why this decision should be reconsidered (at least 20 characters).')?.trim();
+    if(!reason)return;
+    try{await datingProfileApi.appeal(reason);setMessage('Appeal submitted. We’ll notify you after review.')}catch(error){setMessage(errorMessage(error,'We couldn’t submit your appeal.'))}
+  }
+
   return <AppShell>
     <section className="dating-profile">
       <header className="dating-profile-head">
@@ -176,6 +185,10 @@ export function DatingProfilePage(){
         <p className="eyebrow">{profile.discovery_paused?'DISCOVERY PAUSED':'YOUR DATING PROFILE'}</p>
         <h1>{name}</h1>
         <p>{username} · {profile.visibility}</p>
+        <p>Review: {profile.review_status} · Verification: {profile.verification_status}</p>
+        {profile.moderation_note&&<p>{profile.moderation_note}</p>}
+        {profile.review_status==='pending'&&<button className="button secondary" onClick={submitReview}>Submit for review</button>}
+        {profile.review_status==='rejected'&&<button className="button secondary" onClick={appeal}>Appeal decision</button>}
       </header>
       {onboardingMode&&<div className="onboarding-dating-intro"><span>03 / 03</span><p className="eyebrow">YOUR DATING PROFILE</p><h2>Show people what makes you, you.</h2><p>Add photos, choose what you’re looking for, and answer a few prompts. Everything stays editable.</p></div>}
       <ProfileTabs/>

--- a/src/MatchmakingPage.tsx
+++ b/src/MatchmakingPage.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Ban, Heart, Pause, Play, ShieldCheck, Sparkles, UserRoundCheck, X } from 'lucide-react';
+import { Ban, Bell, EyeOff, Flag, Heart, Pause, Play, ShieldCheck, Sparkles, UserRoundCheck, X } from 'lucide-react';
 import { AppShell, Page } from './components';
 import { ApiError } from './lib/api';
-import { matchmakingApi, type DatingMatch, type Introduction } from './lib/matchmaking';
+import { matchmakingApi, type DatingMatch, type Introduction, type MatchmakingNotification } from './lib/matchmaking';
 import './matchmaking.css';
 
 const messageFor=(error:unknown)=>error instanceof ApiError?error.message:'Something interrupted discovery. Please try again.';
@@ -10,17 +10,20 @@ const messageFor=(error:unknown)=>error instanceof ApiError?error.message:'Somet
 export function MatchmakingPage(){
   const [introductions,setIntroductions]=useState<Introduction[]>([]);
   const [matches,setMatches]=useState<DatingMatch[]>([]);
+  const [notifications,setNotifications]=useState<MatchmakingNotification[]>([]);
+  const [inventory,setInventory]=useState<'waitlist'|'reduced'|'open'>('open');
   const [loading,setLoading]=useState(true);
   const [message,setMessage]=useState('');
-  const [tab,setTab]=useState<'discover'|'matches'>('discover');
+  const [tab,setTab]=useState<'discover'|'matches'|'updates'>('discover');
   const [allowFirst,setAllowFirst]=useState(true);
 
   const load=useCallback(async()=>{
     setLoading(true);setMessage('');
-    const [introResult,matchResult]=await Promise.allSettled([matchmakingApi.introductions(),matchmakingApi.matches()]);
-    if(introResult.status==='fulfilled')setIntroductions(introResult.value.items);
+    const [introResult,matchResult,notificationResult]=await Promise.allSettled([matchmakingApi.introductions(),matchmakingApi.matches(),matchmakingApi.notifications()]);
+    if(introResult.status==='fulfilled'){setIntroductions(introResult.value.items);setInventory(introResult.value.inventory_state)}
     else setMessage(messageFor(introResult.reason));
     if(matchResult.status==='fulfilled')setMatches(matchResult.value.items);
+    if(notificationResult.status==='fulfilled')setNotifications(notificationResult.value.items);
     setLoading(false);
   },[]);
   useEffect(()=>{void load()},[load]);
@@ -36,22 +39,26 @@ export function MatchmakingPage(){
   }
   async function unmatch(match:DatingMatch){if(!confirm(`Unmatch ${match.other_display_name}?`))return;try{await matchmakingApi.unmatch(match.id);setMatches(items=>items.filter(item=>item.id!==match.id))}catch(error){setMessage(messageFor(error))}}
   async function block(match:DatingMatch){if(!confirm(`Block ${match.other_display_name}? They will no longer be able to discover or contact you.`))return;try{await matchmakingApi.block(match.other_user_id);setMatches(items=>items.filter(item=>item.id!==match.id))}catch(error){setMessage(messageFor(error))}}
+  async function hide(person:Introduction){try{await matchmakingApi.hide(person.user_id);setIntroductions(items=>items.filter(item=>item.user_id!==person.user_id));setMessage(`${person.display_name} was hidden.`)}catch(error){setMessage(messageFor(error))}}
+  async function report(userId:string,name:string,contextType:'introduction'|'match',contextId?:string){const details=prompt(`Briefly describe what happened with ${name}.`)?.trim();if(!details)return;try{await matchmakingApi.report(userId,contextType,contextId,'other',details);setIntroductions(items=>items.filter(item=>item.user_id!==userId));setMatches(items=>items.filter(item=>item.other_user_id!==userId));setMessage('Report received. This person is hidden from you while our team reviews it.')}catch(error){setMessage(messageFor(error))}}
 
   return <AppShell><div className="matchmaking-page">
     <Page eyebrow="CURATED MATCHMAKING" title="Thoughtful introductions" action={<button className="quiet-action" onClick={pause}><Pause/> Pause</button>}/>
     <p className="matchmaking-intro">A small daily set chosen within both people’s boundaries. Astrology adds context—it never overrides your preferences.</p>
-    <nav className="matchmaking-tabs"><button className={tab==='discover'?'active':''} onClick={()=>setTab('discover')}>Discover <span>{introductions.length}</span></button><button className={tab==='matches'?'active':''} onClick={()=>setTab('matches')}>Matches <span>{matches.length}</span></button></nav>
+    <nav className="matchmaking-tabs"><button className={tab==='discover'?'active':''} onClick={()=>setTab('discover')}>Discover <span>{introductions.length}</span></button><button className={tab==='matches'?'active':''} onClick={()=>setTab('matches')}>Matches <span>{matches.length}</span></button><button className={tab==='updates'?'active':''} onClick={()=>setTab('updates')}>Updates <span>{notifications.filter(item=>!item.read_at).length}</span></button></nav>
     {message&&<p role="status" className="matchmaking-message">{message}</p>}
     {loading&&<p role="status">Preparing today’s introductions…</p>}
     {!loading&&tab==='discover'&&<>
+      {inventory!=='open'&&<p role="status" className="matchmaking-message">{inventory==='waitlist'?'Your local pool is still growing. You’re on the waitlist and we’ll keep your preferences intact.':'Your local pool is limited, so introductions will arrive less often. We won’t relax your boundaries.'}</p>}
       <label className="first-move-choice"><input type="checkbox" checked={allowFirst} onChange={event=>setAllowFirst(event.target.checked)}/><span><strong>They may message first if we match</strong><small>Turn this off when you prefer to make the first move yourself.</small></span></label>
       <div className="introduction-grid">{introductions.map(person=><article className="introduction-card" key={person.user_id}>
         <div className="introduction-photo">{person.photo_url?<img src={person.photo_url} alt={person.display_name}/>:<UserRoundCheck/>}<span>{person.distance_km} km away</span></div>
         <div className="introduction-copy"><p className="eyebrow">{person.relationship_intent.replaceAll('_',' ')}</p><h2>{person.display_name}, {person.age}</h2><p>{person.bio}</p><div className="intro-themes">{person.explanation_themes.map(theme=><span key={theme}><Sparkles/>{theme}</span>)}</div><div className="intro-interests">{person.interests.slice(0,5).map(interest=><span key={interest}>{interest}</span>)}</div></div>
-        <div className="introduction-actions"><button aria-label={`Pass on ${person.display_name}`} onClick={()=>decide(person,'pass')}><X/></button><button className="like" aria-label={`Like ${person.display_name}`} onClick={()=>decide(person,'like')}><Heart/></button></div>
+        <div className="introduction-actions"><button aria-label={`Hide ${person.display_name}`} onClick={()=>hide(person)}><EyeOff/></button><button aria-label={`Report ${person.display_name}`} onClick={()=>report(person.user_id,person.display_name,'introduction')}><Flag/></button><button aria-label={`Pass on ${person.display_name}`} onClick={()=>decide(person,'pass')}><X/></button><button className="like" aria-label={`Like ${person.display_name}`} onClick={()=>decide(person,'like')}><Heart/></button></div>
       </article>)}</div>
       {!introductions.length&&<div className="matchmaking-empty"><Sparkles/><h2>Your daily set is clear</h2><p>We’ll show new people when mutually eligible profiles are available.</p><button className="button secondary" onClick={activate}><Play/> Activate or refresh discovery</button></div>}
     </>}
-    {!loading&&tab==='matches'&&<div className="dating-match-list">{matches.map(match=><article key={match.id}><div>{match.other_photo_url?<img src={match.other_photo_url} alt=""/>:<Heart/>}</div><section><small>MATCHED</small><h2>{match.other_display_name}</h2><p>{match.can_current_user_initiate?'You may make the first move.':'They have the first move.'} Messaging opens in the next matchmaking milestone.</p></section><aside><button onClick={()=>unmatch(match)}>Unmatch</button><button onClick={()=>block(match)}><Ban/> Block</button></aside></article>)}{!matches.length&&<div className="matchmaking-empty"><ShieldCheck/><h2>No mutual matches yet</h2><p>Your likes stay private unless the other person likes you too.</p></div>}</div>}
+    {!loading&&tab==='matches'&&<div className="dating-match-list">{matches.map(match=><article key={match.id}><div>{match.other_photo_url?<img src={match.other_photo_url} alt=""/>:<Heart/>}</div><section><small>MATCHED</small><h2>{match.other_display_name}</h2><p>{match.can_current_user_initiate?'You may make the first move.':'They have the first move.'} Messaging opens in the next matchmaking milestone.</p></section><aside><button onClick={()=>unmatch(match)}>Unmatch</button><button onClick={()=>report(match.other_user_id,match.other_display_name,'match',match.id)}><Flag/> Report</button><button onClick={()=>block(match)}><Ban/> Block</button></aside></article>)}{!matches.length&&<div className="matchmaking-empty"><ShieldCheck/><h2>No mutual matches yet</h2><p>Your likes stay private unless the other person likes you too.</p></div>}</div>}
+    {!loading&&tab==='updates'&&<div className="dating-match-list">{notifications.map(item=><article key={item.id}><div><Bell/></div><section><small>{item.type.replaceAll('_',' ')}</small><h2>{item.title}</h2><p>{item.body}</p></section>{!item.read_at&&<aside><button onClick={async()=>{await matchmakingApi.markNotificationRead(item.id);setNotifications(items=>items.map(value=>value.id===item.id?{...value,read_at:new Date().toISOString()}:value))}}>Mark read</button></aside>}</article>)}{!notifications.length&&<div className="matchmaking-empty"><Bell/><h2>No updates yet</h2></div>}</div>}
   </div></AppShell>;
 }

--- a/src/api/generated/openapi.yaml
+++ b/src/api/generated/openapi.yaml
@@ -82,6 +82,10 @@ paths:
     post: {tags: [Matchmaking],summary: Validate the complete dating profile and activate discovery,responses: {'200': {$ref: '#/components/responses/Success'},'422': {$ref: '#/components/responses/Error'}}}
   /api/v1/me/dating-profile/pause:
     post: {tags: [Matchmaking],summary: Immediately pause new discovery presentation,responses: {'200': {$ref: '#/components/responses/Success'}}}
+  /api/v1/me/dating-profile/submit-review:
+    post: {tags: [Safety],summary: Submit a completed dating profile to the moderation queue,responses: {'202': {$ref: '#/components/responses/Success'}}}
+  /api/v1/me/dating-profile/appeals:
+    post: {tags: [Safety],summary: Appeal the latest restriction or rejection,requestBody: {required: true,content: {application/json: {schema: {type: object,required: [reason],properties: {reason: {type: string,minLength: 20,maxLength: 1000}}}}}},responses: {'201': {$ref: '#/components/responses/Success'},'409': {$ref: '#/components/responses/Error'},'422': {$ref: '#/components/responses/Error'}}}
   /api/v1/discovery/introductions:
     get: {tags: [Matchmaking],summary: Get up to five stable mutually eligible introductions for the UTC day,responses: {'200': {$ref: '#/components/responses/Introductions'},'403': {$ref: '#/components/responses/Error'}}}
   /api/v1/discovery/introductions/{user_id}/decision:
@@ -104,6 +108,29 @@ paths:
       - {name: user_id,in: path,required: true,schema: {type: string,format: uuid}}
     put: {tags: [Safety],summary: Block a user and immediately revoke discovery and match access,responses: {'204': {description: Block active},'403': {$ref: '#/components/responses/Error'}}}
     delete: {tags: [Safety],summary: Remove the current user's block,responses: {'204': {description: Block removed}}}
+  /api/v1/safety/hides/{user_id}:
+    parameters: [{name: user_id,in: path,required: true,schema: {type: string,format: uuid}}]
+    put: {tags: [Safety],summary: Privately remove a profile from future discovery,responses: {'204': {description: Profile hidden}}}
+    delete: {tags: [Safety],summary: Remove a private hide,responses: {'204': {description: Hide removed}}}
+  /api/v1/safety/reports:
+    post:
+      tags: [Safety]
+      summary: Report and immediately hide a profile; urgent or repeated reports pause discovery for review
+      parameters: [{$ref: '#/components/parameters/IdempotencyKey'}]
+      requestBody: {required: true,content: {application/json: {schema: {$ref: '#/components/schemas/UserReportInput'}}}}
+      responses: {'201': {$ref: '#/components/responses/Success'},'403': {$ref: '#/components/responses/Error'},'422': {$ref: '#/components/responses/Error'}}
+  /api/v1/matchmaking/notifications:
+    get: {tags: [Matchmaking],summary: List the latest 50 matchmaking and moderation notifications,responses: {'200': {$ref: '#/components/responses/Success'}}}
+  /api/v1/matchmaking/notifications/{id}/read:
+    parameters: [{$ref: '#/components/parameters/ID'}]
+    put: {tags: [Matchmaking],summary: Idempotently mark a notification read,responses: {'204': {description: Notification read},'404': {$ref: '#/components/responses/Error'}}}
+  /api/v1/moderation/matchmaking/cases:
+    get: {tags: [Safety],summary: List prioritized open moderation cases (moderator only),responses: {'200': {$ref: '#/components/responses/Success'},'403': {$ref: '#/components/responses/Error'}}}
+  /api/v1/moderation/matchmaking/cases/{id}:
+    parameters: [{$ref: '#/components/parameters/ID'}]
+    put: {tags: [Safety],summary: Resolve and audit a moderation case (moderator only),requestBody: {required: true,content: {application/json: {schema: {$ref: '#/components/schemas/ModerationResolution'}}}},responses: {'200': {$ref: '#/components/responses/Success'},'403': {$ref: '#/components/responses/Error'},'422': {$ref: '#/components/responses/Error'}}}
+  /api/v1/moderation/matchmaking/metrics:
+    get: {tags: [Safety],summary: Review marketplace safety density and exposure concentration (moderator only),responses: {'200': {$ref: '#/components/responses/Success'},'403': {$ref: '#/components/responses/Error'}}}
   /api/v1/birth-profiles:
     get:
       tags: [Birth Charts]
@@ -337,6 +364,8 @@ components:
         has_discovery_location: {type: boolean,readOnly: true}
         allow_match_to_message_first: {type: boolean}
         review_status: {type: string,enum: [pending,approved,rejected],readOnly: true}
+        verification_status: {type: string,enum: [unverified,pending,verified,rejected],readOnly: true}
+        moderation_note: {type: [string,'null'],maxLength: 1000,readOnly: true}
         dating_prompts: {type: array,maxItems: 3,items: {$ref: '#/components/schemas/DatingPrompt'}}
         questions: {type: array,maxItems: 3,items: {$ref: '#/components/schemas/DatingQuestion'}}
         photos: {type: array,maxItems: 6,items: {$ref: '#/components/schemas/DatingPhoto'}}
@@ -378,6 +407,26 @@ components:
         photo_url: {type: [string,'null'],format: uri}
         rank_score: {type: integer,minimum: 0,maximum: 100}
         compatibility_score: {type: integer,minimum: 0,maximum: 100}
+        ranking_version: {type: string}
+        eligibility_reason_codes: {type: array,items: {type: string}}
+        explanation_themes: {type: array,items: {type: string}}
+    UserReportInput:
+      type: object
+      required: [reported_user_id,category,context_type]
+      additionalProperties: false
+      properties:
+        reported_user_id: {type: string,format: uuid}
+        category: {type: string,enum: [impersonation,harassment,sexual_content,hate,spam,underage,offline_safety,other]}
+        details: {type: [string,'null'],maxLength: 1000}
+        context_type: {type: string,enum: [introduction,match,profile]}
+        context_id: {type: [string,'null'],format: uuid}
+    ModerationResolution:
+      type: object
+      required: [resolution,reason]
+      additionalProperties: false
+      properties:
+        resolution: {type: string,enum: [approved,warned,restricted,rejected,dismissed]}
+        reason: {type: string,minLength: 3,maxLength: 1000}
         explanation_themes: {type: array,items: {type: string}}
     IntroductionDecision:
       type: object
@@ -507,7 +556,7 @@ components:
     BirthProfile: {description: Birth profile with active chart reference,content: {application/json: {schema: {type: object,properties: {data: {$ref: '#/components/schemas/BirthProfile'}}}}}}
     Chart: {description: Active deterministic chart and source profile,content: {application/json: {schema: {type: object,properties: {data: {type: object,properties: {birth_profile: {$ref: '#/components/schemas/BirthProfile'},chart: {$ref: '#/components/schemas/ChartCalculation'}}}}}}}}
     DatingProfile: {description: Current user's editable dating profile,content: {application/json: {schema: {type: object,properties: {data: {$ref: '#/components/schemas/DatingProfile'}}}}}}
-    Introductions: {description: Daily curated introductions,content: {application/json: {schema: {type: object,properties: {data: {type: object,properties: {items: {type: array,maxItems: 5,items: {$ref: '#/components/schemas/MatchmakingIntroduction'}}}}}}}}}
+    Introductions: {description: Daily curated introductions with sparse-market state,content: {application/json: {schema: {type: object,properties: {data: {type: object,properties: {items: {type: array,maxItems: 5,items: {$ref: '#/components/schemas/MatchmakingIntroduction'}},inventory_state: {enum: [waitlist,reduced,open]},cadence: {enum: [waitlist,reduced,daily]},eligible_count: {type: integer,minimum: 0},ranking_version: {type: string}}}}}}}}
     Decision: {description: Persisted decision and optional newly created mutual match,content: {application/json: {schema: {type: object,properties: {data: {type: object,properties: {decision: {enum: [like,pass]},match: {oneOf: [{$ref: '#/components/schemas/DatingMatch'},{type: 'null'}]}}}}}}}}
     DatingMatch: {description: Mutual dating match,content: {application/json: {schema: {type: object,properties: {data: {$ref: '#/components/schemas/DatingMatch'}}}}}}
     DatingMatches: {description: Active mutual dating matches,content: {application/json: {schema: {type: object,properties: {data: {type: object,properties: {items: {type: array,items: {$ref: '#/components/schemas/DatingMatch'}}}}}}}}}

--- a/src/api/generated/schema.ts
+++ b/src/api/generated/schema.ts
@@ -550,6 +550,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/me/dating-profile/submit-review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Submit a completed dating profile to the moderation queue */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                202: components["responses"]["Success"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me/dating-profile/appeals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Appeal the latest restriction or rejection */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        reason: string;
+                    };
+                };
+            };
+            responses: {
+                201: components["responses"]["Success"];
+                409: components["responses"]["Error"];
+                422: components["responses"]["Error"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/discovery/introductions": {
         parameters: {
             query?: never;
@@ -758,6 +822,263 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/safety/hides/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        /** Privately remove a profile from future discovery */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    user_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Profile hidden */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        /** Remove a private hide */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    user_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Hide removed */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/safety/reports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Report and immediately hide a profile; urgent or repeated reports pause discovery for review */
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    "Idempotency-Key": components["parameters"]["IdempotencyKey"];
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UserReportInput"];
+                };
+            };
+            responses: {
+                201: components["responses"]["Success"];
+                403: components["responses"]["Error"];
+                422: components["responses"]["Error"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/matchmaking/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the latest 50 matchmaking and moderation notifications */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                200: components["responses"]["Success"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/matchmaking/notifications/{id}/read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["ID"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        /** Idempotently mark a notification read */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: components["parameters"]["ID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Notification read */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                404: components["responses"]["Error"];
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/moderation/matchmaking/cases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List prioritized open moderation cases (moderator only) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                200: components["responses"]["Success"];
+                403: components["responses"]["Error"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/moderation/matchmaking/cases/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["ID"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        /** Resolve and audit a moderation case (moderator only) */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: components["parameters"]["ID"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ModerationResolution"];
+                };
+            };
+            responses: {
+                200: components["responses"]["Success"];
+                403: components["responses"]["Error"];
+                422: components["responses"]["Error"];
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/moderation/matchmaking/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Review marketplace safety density and exposure concentration (moderator only) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                200: components["responses"]["Success"];
+                403: components["responses"]["Error"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -2447,6 +2768,9 @@ export interface components {
             allow_match_to_message_first?: boolean;
             /** @enum {string} */
             readonly review_status?: "pending" | "approved" | "rejected";
+            /** @enum {string} */
+            readonly verification_status?: "unverified" | "pending" | "verified" | "rejected";
+            readonly moderation_note?: string | null;
             dating_prompts?: components["schemas"]["DatingPrompt"][];
             questions?: components["schemas"]["DatingQuestion"][];
             photos?: components["schemas"]["DatingPhoto"][];
@@ -2500,7 +2824,26 @@ export interface components {
             photo_url?: string | null;
             rank_score: number;
             compatibility_score: number;
+            ranking_version?: string;
+            eligibility_reason_codes?: string[];
             explanation_themes: string[];
+        };
+        UserReportInput: {
+            /** Format: uuid */
+            reported_user_id: string;
+            /** @enum {string} */
+            category: "impersonation" | "harassment" | "sexual_content" | "hate" | "spam" | "underage" | "offline_safety" | "other";
+            details?: string | null;
+            /** @enum {string} */
+            context_type: "introduction" | "match" | "profile";
+            /** Format: uuid */
+            context_id?: string | null;
+        };
+        ModerationResolution: {
+            /** @enum {string} */
+            resolution: "approved" | "warned" | "restricted" | "rejected" | "dismissed";
+            reason: string;
+            explanation_themes?: string[];
         };
         IntroductionDecision: {
             /** @enum {string} */
@@ -2794,7 +3137,7 @@ export interface components {
                 };
             };
         };
-        /** @description Daily curated introductions */
+        /** @description Daily curated introductions with sparse-market state */
         Introductions: {
             headers: {
                 [name: string]: unknown;
@@ -2803,6 +3146,12 @@ export interface components {
                 "application/json": {
                     data?: {
                         items?: components["schemas"]["MatchmakingIntroduction"][];
+                        /** @enum {unknown} */
+                        inventory_state?: "waitlist" | "reduced" | "open";
+                        /** @enum {unknown} */
+                        cadence?: "waitlist" | "reduced" | "daily";
+                        eligible_count?: number;
+                        ranking_version?: string;
                     };
                 };
             };

--- a/src/lib/datingProfile.ts
+++ b/src/lib/datingProfile.ts
@@ -47,6 +47,8 @@ export interface DatingProfile {
 	has_discovery_location:boolean;
 	allow_match_to_message_first:boolean;
 	review_status:'pending'|'approved'|'rejected';
+  verification_status:'unverified'|'pending'|'verified'|'rejected';
+  moderation_note?:string|null;
   prompts:DatingPrompt[];
   questions:DatingQuestion[];
   photos:DatingPhoto[];
@@ -109,6 +111,8 @@ export function validateDatingPhoto(file:File){
 
 export const datingProfileApi={
   get:()=>api<DatingProfile>('/api/v1/me/dating-profile'),
+  submitReview:()=>api<{id:string;status:string}>('/api/v1/me/dating-profile/submit-review',{method:'POST'}),
+  appeal:(reason:string)=>api<{id:string;status:string}>('/api/v1/me/dating-profile/appeals',{method:'POST',body:JSON.stringify({reason})}),
   patch:(patch:DatingProfilePatch)=>retry503(()=>api<DatingProfile>('/api/v1/me/dating-profile',{
     method:'PATCH',
     body:JSON.stringify(patch),

--- a/src/lib/matchmaking.test.ts
+++ b/src/lib/matchmaking.test.ts
@@ -22,4 +22,18 @@ describe('matchmaking API contract',()=>{
     await matchmakingApi.decide('candidate-1','pass',true);
     expect(apiMock).toHaveBeenCalledWith('/api/v1/discovery/introductions/candidate-1/decision',expect.objectContaining({body:JSON.stringify({decision:'pass'})}));
   });
+  it('reports with an idempotency key and interaction context',async()=>{
+    apiMock.mockResolvedValue({id:'report-1',status:'open'});
+    await matchmakingApi.report('candidate-1','match','match-1','harassment','Repeated unwanted contact');
+    expect(apiMock).toHaveBeenCalledWith('/api/v1/safety/reports',{
+      method:'POST',headers:{'Idempotency-Key':'test-key'},body:JSON.stringify({reported_user_id:'candidate-1',category:'harassment',details:'Repeated unwanted contact',context_type:'match',context_id:'match-1'}),
+    });
+  });
+  it('supports private hides and durable notification reads',async()=>{
+    apiMock.mockResolvedValue(undefined);
+    await matchmakingApi.hide('candidate-1');
+    await matchmakingApi.markNotificationRead('notification-1');
+    expect(apiMock).toHaveBeenNthCalledWith(1,'/api/v1/safety/hides/candidate-1',{method:'PUT'});
+    expect(apiMock).toHaveBeenNthCalledWith(2,'/api/v1/matchmaking/notifications/notification-1/read',{method:'PUT'});
+  });
 });

--- a/src/lib/matchmaking.ts
+++ b/src/lib/matchmaking.ts
@@ -14,6 +14,8 @@ export interface Introduction {
   rank_score:number;
   compatibility_score:number;
   explanation_themes:string[];
+  ranking_version:string;
+  eligibility_reason_codes:string[];
 }
 
 export interface DatingMatch {
@@ -32,14 +34,21 @@ export interface DecisionResult {
   match?:DatingMatch;
 }
 
+export interface DiscoveryResult {items:Introduction[];inventory_state:'waitlist'|'reduced'|'open';cadence:'waitlist'|'reduced'|'daily';eligible_count:number;ranking_version:string}
+export interface MatchmakingNotification {id:string;type:string;title:string;body:string;resource_type:string|null;resource_id:string|null;created_at:string;read_at:string|null}
+
 export const matchmakingApi={
   activate:()=>api<{discovery_active:boolean;discovery_paused:boolean}>('/api/v1/me/dating-profile/activate',{method:'POST'}),
   pause:()=>api<{discovery_active:boolean;discovery_paused:boolean}>('/api/v1/me/dating-profile/pause',{method:'POST'}),
-  introductions:()=>api<{items:Introduction[]}>('/api/v1/discovery/introductions'),
+  introductions:()=>api<DiscoveryResult>('/api/v1/discovery/introductions'),
   decide:(userId:string,decision:'like'|'pass',allowMatchToMessageFirst?:boolean)=>api<DecisionResult>(`/api/v1/discovery/introductions/${userId}/decision`,{
     method:'PUT',headers:idempotencyHeaders(),body:JSON.stringify({decision,...(decision==='like'?{allow_match_to_message_first:allowMatchToMessageFirst}: {})}),
   }),
   matches:()=>api<{items:DatingMatch[]}>('/api/v1/dating-matches'),
   unmatch:(matchId:string)=>api<void>(`/api/v1/dating-matches/${matchId}`,{method:'DELETE'}),
   block:(userId:string)=>api<void>(`/api/v1/safety/blocks/${userId}`,{method:'PUT'}),
+  hide:(userId:string)=>api<void>(`/api/v1/safety/hides/${userId}`,{method:'PUT'}),
+  report:(userId:string,contextType:'introduction'|'match'|'profile',contextId:string|undefined,category:string,details:string)=>api<{id:string;status:string}>('/api/v1/safety/reports',{method:'POST',headers:idempotencyHeaders(),body:JSON.stringify({reported_user_id:userId,category,details,context_type:contextType,context_id:contextId})}),
+  notifications:()=>api<{items:MatchmakingNotification[]}>('/api/v1/matchmaking/notifications'),
+  markNotificationRead:(id:string)=>api<void>(`/api/v1/matchmaking/notifications/${id}/read`,{method:'PUT'}),
 };


### PR DESCRIPTION
## Summary
- show waitlist/reduced-inventory states without loosening user preferences
- add private hide and report flows for introductions and matches
- add review submission, appeal state, and durable matchmaking/moderation updates
- regenerate the client contract from backend OpenAPI

## Validation
- `npm test -- --run` (39 tests)
- `npm run build`
- `git diff --check`

Depends on the matching backend beta-readiness PR.